### PR TITLE
Download CLI only if newer version available (#5)

### DIFF
--- a/WakaTime/ConfigFile.swift
+++ b/WakaTime/ConfigFile.swift
@@ -8,15 +8,22 @@
 import Foundation
 
 struct ConfigFile {
+    private static var filePath: String {
+        NSString.path(withComponents: FileManager.default.homeDirectoryForCurrentUser.pathComponents + [".wakatime.cfg"])
+    }
 
-    static func getSetting(section: String, key: String) -> String {
-        let file = NSString.path(withComponents: FileManager.default.homeDirectoryForCurrentUser.pathComponents + [".wakatime.cfg"])
+    private static var filePathInternal: String {
+        NSString.path(withComponents: FileManager.default.homeDirectoryForCurrentUser.pathComponents + [".wakatime-internal.cfg"])
+    }
+
+    static func getSetting(section: String, key: String, internalConfig: Bool = false) -> String? {
+        let file = internalConfig ? Self.filePathInternal : Self.filePath
         let contents: String
         do {
             contents = try String(contentsOfFile: file)
         } catch {
             print("Failed reading \(file): " + error.localizedDescription)
-            return ""
+            return nil
         }
         let lines = contents.split(separator:"\n")
         
@@ -31,11 +38,11 @@ struct ConfigFile {
                 }
             }
         }
-        return ""
+        return nil
     }
     
-    static func setSetting(section: String, key: String, val: String) {
-        let file = NSString.path(withComponents: FileManager.default.homeDirectoryForCurrentUser.pathComponents + [".wakatime.cfg"])
+    static func setSetting(section: String, key: String, val: String, internalConfig: Bool = false) {
+        let file = internalConfig ? Self.filePathInternal : Self.filePath
         let contents: String
         do {
             contents = try String(contentsOfFile: file)

--- a/WakaTime/WakaTime.swift
+++ b/WakaTime/WakaTime.swift
@@ -14,7 +14,9 @@ struct WakaTime: App {
 
     init() {
         registerAsLoginItem()
-        downloadCLI()
+        self.isCLILatest { [self] isLatest in
+            if !isLatest { self.downloadCLI() }
+        }
         requestA11yPermission()
         watcher.changeHandler = documentChanged
         checkForApiKey()
@@ -36,7 +38,7 @@ struct WakaTime: App {
     
     private func checkForApiKey() {
         let apiKey = ConfigFile.getSetting(section: "settings", key: "api_key")
-        if apiKey == "" {
+        if apiKey == nil {
             promptForApiKey()
         }
     }
@@ -44,7 +46,7 @@ struct WakaTime: App {
     private func promptForApiKey() {
         openWindow(id: "settings")
         NSApp.activate(ignoringOtherApps: true)
-        settings.apiKey = ConfigFile.getSetting(section: "settings", key: "api_key")
+        settings.apiKey = ConfigFile.getSetting(section: "settings", key: "api_key") ?? ""
     }
 
     private func registerAsLoginItem() {
@@ -63,6 +65,86 @@ struct WakaTime: App {
         let appHasPermission = AXIsProcessTrustedWithOptions(options)
         if appHasPermission {
             // print("has a11y permission")
+        }
+    }
+    
+    private func getLatestVersion(completion: @escaping ((String?, Error?) -> Void)) {
+        struct Release: Decodable {
+            let tagName: String
+            private enum CodingKeys: String, CodingKey {
+                case tagName = "tag_name"
+            }
+        }
+        
+        let apiUrl = "https://api.github.com/repos/wakatime/wakatime-cli/releases/latest"
+        var request = URLRequest(url: URL(string: apiUrl)!, cachePolicy: .reloadIgnoringCacheData)
+        let lastModified = ConfigFile.getSetting(section: "internal", key: "cli_version_last_modified", internalConfig: true)
+        let currentVersion = ConfigFile.getSetting(section: "internal", key: "cli_version", internalConfig: true)
+        if let lastModified, currentVersion != nil {
+            request.setValue(lastModified, forHTTPHeaderField: "If-Modified-Since")
+        }
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            guard let data, let httpResponse = response as? HTTPURLResponse else {
+                completion(nil, error)
+                return
+            }
+            if httpResponse.statusCode == 304 {
+                DispatchQueue.main.async {
+                    // Current version is still the latest version available
+                    completion(currentVersion, nil)
+                }
+            } else if let lastModified = httpResponse.value(forHTTPHeaderField: "Last-Modified"),
+                      let release = try? JSONDecoder().decode(Release.self, from: data) {
+                // Remote version successfully decoded
+                ConfigFile.setSetting(section: "internal", key: "cli_version_last_modified", val: lastModified, internalConfig: true)
+                ConfigFile.setSetting(section: "internal", key: "cli_version", val: release.tagName, internalConfig: true)
+                DispatchQueue.main.async {
+                    completion(release.tagName, nil)
+                }
+            } else {
+                DispatchQueue.main.async {
+                    // Unexpected response
+                    completion(nil, nil)
+                }
+            }
+        }.resume()
+    }
+    
+    private func isCLILatest(completion: @escaping (Bool) -> Void) {
+        let cli = NSString.path(withComponents: FileManager.default.homeDirectoryForCurrentUser.pathComponents + [".wakatime", "wakatime-cli"])
+        guard FileManager.default.fileExists(atPath: cli) else {
+            completion(false)
+            return
+        }
+        let outputPipe = Pipe()
+        let process = Process()
+        process.launchPath = cli
+        process.arguments = ["--version"]
+        process.standardOutput = outputPipe
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+        } catch {
+            // Error running CLI process
+            completion(false)
+            return
+        }
+        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(decoding: outputData, as: UTF8.self)
+        let version = output.firstMatch(of: /([0-9]+\.[0-9]+\.[0-9]+)/)
+        getLatestVersion { remoteVersion, error in
+            guard let remoteVersion, error == nil else {
+                // Could not retrieve remote version
+                completion(true)
+                return
+            }
+            if let version, "v" + version.0 == remoteVersion {
+                // Local version up to date
+                completion(true)
+            } else {
+                // Newer version available
+                completion(false)
+            }
         }
     }
     


### PR DESCRIPTION
Regarding `ConfigFile`: I added only the changes that were necessary for working with the internal config and left my parser changes out. Most notably, both `getSetting()` and `setSetting()` now have a parameter `internalConfig` defaulting to `false`. I will leave some comments inline.

A general remark: I didn't add logging. Let me know if you need it and I can add it quickly. I saw it's present e.g. in the vim extension, but wasn't sure if you wanted in in the Mac app.