### PR TITLE
Add version number to settings #54 #53

### DIFF
--- a/WakaTime/BundleExtension.swift
+++ b/WakaTime/BundleExtension.swift
@@ -1,0 +1,26 @@
+//
+//  BundleExtension.swift
+//  WakaTime
+//
+//  Created by chester on 2023/4/2.
+//
+
+import Foundation
+
+extension Bundle {
+    var displayName: String {
+        readFromInfoDict(key: "CFBundleDisplayName") ?? "displayName null"
+    }
+
+    var version: String {
+        readFromInfoDict(key: "CFBundleShortVersionString") ?? "version null"
+    }
+
+    var build: String {
+        readFromInfoDict(key: "CFBundleVersion") ?? "build null"
+    }
+
+    private func readFromInfoDict(key: String) -> String? {
+        infoDictionary?[key] as? String
+    }
+}

--- a/WakaTime/Settings.swift
+++ b/WakaTime/Settings.swift
@@ -22,6 +22,8 @@ struct SettingsView: View {
                     }
                     .keyboardShortcut(.cancelAction)
                 }
+                Text("Version: \(Bundle.main.version) (\(Bundle.main.build))")
+                    .padding()
             }
             .padding()
         }


### PR DESCRIPTION
I got issue #54  then want to check the version number but cant find it in setting, so add it:

<img width="464" alt="Screenshot 2023-04-02 at 21 59 13" src="https://user-images.githubusercontent.com/8273263/229357890-39eaa79a-9519-47ac-ad1f-305acff799f4.png">

BTW:
1. Version: #53 should be fixed to show the correct version.
2. Build: You can consider to auto update build by commit count. [REF](https://gist.github.com/alparslandev/51ad5bc0192ad4d52ffcac02d5e3b541#file-set_build_number_by_git_commits-sh)

