### PR TITLE
Use unknown string when version null

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           valueFile: 'project.yml'
           propertyPath: 'targets.WakaTime.settings.MARKETING_VERSION'
-          value: ${{ needs.version.outputs.semver_tag }}
+          value: echo ${{ needs.version.outputs.semver_tag }} | sed 's/^v//'
           commitChange: false
       -
         name: Install xcodegen via Homebrew for linting and building xcode project

--- a/WakaTime/BundleExtension.swift
+++ b/WakaTime/BundleExtension.swift
@@ -1,23 +1,16 @@
-//
-//  BundleExtension.swift
-//  WakaTime
-//
-//  Created by chester on 2023/4/2.
-//
-
 import Foundation
 
 extension Bundle {
     var displayName: String {
-        readFromInfoDict(key: "CFBundleDisplayName") ?? "displayName null"
+        readFromInfoDict(key: "CFBundleDisplayName") ?? "unknown"
     }
 
     var version: String {
-        readFromInfoDict(key: "CFBundleShortVersionString") ?? "version null"
+        readFromInfoDict(key: "CFBundleShortVersionString") ?? "unknown"
     }
 
     var build: String {
-        readFromInfoDict(key: "CFBundleVersion") ?? "build null"
+        readFromInfoDict(key: "CFBundleVersion") ?? "unknown"
     }
 
     private func readFromInfoDict(key: String) -> String? {

--- a/WakaTime/ConfigFile.swift
+++ b/WakaTime/ConfigFile.swift
@@ -1,10 +1,3 @@
-//
-//  ConfigFile.swift
-//  WakaTime
-//
-//  Created by Alan Hamlett on 3/6/23.
-//
-
 import Foundation
 
 struct ConfigFile {

--- a/WakaTime/WakaTime.swift
+++ b/WakaTime/WakaTime.swift
@@ -12,7 +12,6 @@ struct WakaTime: App {
     var state = State()
 
     let watcher = Watcher()
-    let version = Bundle.main.infoDictionary!["CFBundleShortVersionString"] as! String
 
     enum Constants {
         static let settingsDeepLink: String = "wakatime://settings"
@@ -270,7 +269,7 @@ struct WakaTime: App {
         )
         let process = Process()
         process.launchPath = cli
-        var args = ["--entity", file.formatted(), "--plugin", "xcode/\(xcodeVersion) xcode-wakatime/" + version]
+        var args = ["--entity", file.formatted(), "--plugin", "xcode/\(xcodeVersion) xcode-wakatime/" + Bundle.main.version]
         if isWrite {
             args.append("--write")
         }

--- a/WakaTime/Watcher.swift
+++ b/WakaTime/Watcher.swift
@@ -56,14 +56,10 @@ class Watcher: NSObject {
     private func setXcodeVersion(_ app: NSRunningApplication) {
         guard
             let url = app.bundleURL,
-            let bundle = Bundle(url: url),
-            let info = bundle.infoDictionary
+            let bundle = Bundle(url: url)
         else { return }
 
-        let build = info["CFBundleVersion"] as! String
-        let version = info["CFBundleShortVersionString"] as! String
-
-        xcodeVersion = "\(version)-\(build)"
+        xcodeVersion = "\(bundle.version)-\(bundle.build)"
     }
 
     private func watch(app: NSRunningApplication) {


### PR DESCRIPTION
Because these strings are used in the `User-Agent` header and separated by space to find the xcode version, macos-wakatime version, and wakatime-cli version... we should prevent having spaces in the version number strings.

Also changes:

* uses the bundle extension attributes for version and build instead of reading keys directly
* removes `v` prefix from version when updating `project.yml`