### PR TITLE
Use new internal cfg location

### DIFF
--- a/WakaTime/ConfigFile.swift
+++ b/WakaTime/ConfigFile.swift
@@ -1,12 +1,20 @@
 import Foundation
 
 struct ConfigFile {
+    private static var userHome: [String] {
+        FileManager.default.homeDirectoryForCurrentUser.pathComponents
+    }
+    
+    public static var resourcesFolder: [String] {
+        userHome + [".wakatime"]
+    }
+    
     private static var filePath: String {
-        NSString.path(withComponents: FileManager.default.homeDirectoryForCurrentUser.pathComponents + [".wakatime.cfg"])
+        NSString.path(withComponents: userHome + [".wakatime.cfg"])
     }
 
     private static var filePathInternal: String {
-        NSString.path(withComponents: FileManager.default.homeDirectoryForCurrentUser.pathComponents + [".wakatime-internal.cfg"])
+        NSString.path(withComponents: resourcesFolder + ["wakatime-internal.cfg"])
     }
 
     static func getSetting(section: String, key: String, internalConfig: Bool = false) -> String? {

--- a/WakaTime/WakaTime.swift
+++ b/WakaTime/WakaTime.swift
@@ -118,7 +118,7 @@ struct WakaTime: App {
 
     private static func isCLILatest() async -> Bool {
         let cli = NSString.path(
-            withComponents: FileManager.default.homeDirectoryForCurrentUser.pathComponents + [".wakatime", "wakatime-cli"]
+            withComponents: ConfigFile.resourcesFolder + ["wakatime-cli"]
         )
         guard FileManager.default.fileExists(atPath: cli) else { return false }
 
@@ -152,7 +152,7 @@ struct WakaTime: App {
     }
 
     private static func downloadCLI() {
-        let dir = NSString.path(withComponents: FileManager.default.homeDirectoryForCurrentUser.pathComponents + [".wakatime"])
+        let dir = NSString.path(withComponents: ConfigFile.resourcesFolder)
         if !FileManager.default.fileExists(atPath: dir) {
             do {
                 try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true, attributes: nil)
@@ -162,16 +162,9 @@ struct WakaTime: App {
         }
 
         let url = "https://github.com/wakatime/wakatime-cli/releases/latest/download/wakatime-cli-darwin-\(architecture()).zip"
-        let zipFile = NSString.path(
-            withComponents: FileManager.default.homeDirectoryForCurrentUser.pathComponents + [".wakatime", "wakatime-cli.zip"]
-        )
-        let cli = NSString.path(
-            withComponents: FileManager.default.homeDirectoryForCurrentUser.pathComponents + [".wakatime", "wakatime-cli"]
-        )
-        let cliReal = NSString.path(
-            withComponents:
-                FileManager.default.homeDirectoryForCurrentUser.pathComponents + [".wakatime", "wakatime-cli-darwin-\(architecture())"]
-        )
+        let zipFile = NSString.path(withComponents: ConfigFile.resourcesFolder + ["wakatime-cli.zip"])
+        let cli = NSString.path(withComponents: ConfigFile.resourcesFolder + ["wakatime-cli"])
+        let cliReal = NSString.path(withComponents: ConfigFile.resourcesFolder + ["wakatime-cli-darwin-\(architecture())"])
 
         if FileManager.default.fileExists(atPath: zipFile) {
             do {
@@ -267,7 +260,7 @@ struct WakaTime: App {
         state.lastTime = time
 
         let cli = NSString.path(
-            withComponents: FileManager.default.homeDirectoryForCurrentUser.pathComponents + [".wakatime", "wakatime-cli"]
+            withComponents: ConfigFile.resourcesFolder + ["wakatime-cli"]
         )
         let process = Process()
         process.launchPath = cli


### PR DESCRIPTION
We're slowly moving all config files into `~/.wakatime/` to cleanup `$HOME`.