### PR TITLE
Fix signing helper bundle

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -105,6 +105,41 @@ jobs:
           # The password used to import the PKCS12 file.
           p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
       -
+        name: Codesign helper bundle
+        run: /usr/bin/codesign --force -s "WakaTime" --options runtime build/Release/WakaTime.app/Contents/Resources/WakaTime\ Helper.app -v
+      -
+        name: Notarize helper bundle
+        env:
+          NOTARIZATION_APPLE_ID: ${{ secrets.AC_USERNAME }}
+          NOTARIZATION_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          NOTARIZATION_PWD: ${{ secrets.AC_PASSWORD }}
+        run: |
+          # Store the notarization credentials so that we can prevent a UI password dialog
+          # from blocking the CI
+
+          echo "Create keychain profile"
+          xcrun notarytool store-credentials "notarytool-profile" --apple-id "$NOTARIZATION_APPLE_ID" --team-id "$NOTARIZATION_TEAM_ID" --password "$NOTARIZATION_PWD"
+
+          # We can't notarize an app bundle directly, but we need to compress it as an archive.
+          # Therefore, we create a zip file containing our app bundle, so that we can send it to the
+          # notarization service
+
+          echo "Creating temp notarization archive"
+          ditto -c -k --keepParent "build/Release/WakaTime.app/Contents/Resources/WakaTime\ Helper.app" "helper_notarization.zip"
+
+          # Here we send the notarization request to the Apple's Notarization service, waiting for the result.
+          # This typically takes a few seconds inside a CI environment, but it might take more depending on the App
+          # characteristics. Visit the Notarization docs for more information and strategies on how to optimize it if
+          # you're curious
+
+          echo "Notarize app"
+          xcrun notarytool submit "helper_notarization.zip" --keychain-profile "notarytool-profile" --wait
+
+          # Finally, we need to "attach the staple" to our executable, which will allow our app to be
+          # validated by macOS even when an internet connection is not available.
+          echo "Attach staple"
+          xcrun stapler staple "build/Release/WakaTime.app/Contents/Resources/WakaTime\ Helper.app"
+      -
         name: Codesign app bundle
         run: /usr/bin/codesign --force -s "WakaTime" --options runtime build/Release/WakaTime.app -v
       -


### PR DESCRIPTION
Fixes the failing github action when releasing new version:

```
Create keychain profile

This process stores your credentials securely in the Keychain. You reference these credentials later using a profile name.

Validating your credentials...
Success. Credentials validated.
Credentials saved to Keychain.
To use them, specify `--keychain-profile "notarytool-profile"`
Creating temp notarization archive
Notarize app
Conducting pre-submission checks for notarization.zip and initiating connection to the Apple notary service...
Submission ID received
  id: 2e388786-0fce-4db1-bec5-920c528[34](https://github.com/wakatime/macos-wakatime/actions/runs/5199084790/jobs/9376115257#step:9:35)[38](https://github.com/wakatime/macos-wakatime/actions/runs/5199084790/jobs/9376115257#step:9:39)c
Successfully uploaded file
  id: 2e388786-0fce-4db1-bec5-920c5283[43](https://github.com/wakatime/macos-wakatime/actions/runs/5199084790/jobs/9376115257#step:9:44)8c
  path: /Users/runner/work/macos-wakatime/macos-wakatime/notarization.zip
Waiting for processing to complete.

Current status: In Progress...
Current status: In Progress....
Current status: Invalid.....Processing complete
  id: 2e388786-0fce-4db1-bec5-920c5283438c
  status: Invalid

Attach staple
Processing: /Users/runner/work/macos-wakatime/macos-wakatime/build/Release/WakaTime.app
CloudKit query for WakaTime.app (2/65d5553ba7f6fdab15e04f22bddd0[49](https://github.com/wakatime/macos-wakatime/actions/runs/5199084790/jobs/9376115257#step:9:50)1f8c5b895) failed due to "Record not found".
Could not find base64 encoded ticket in response for 2/65d55[53](https://github.com/wakatime/macos-wakatime/actions/runs/5199084790/jobs/9376115257#step:9:54)ba7f6fdab15e04f22bddd0491f8c5b895
The staple and validate action failed! Error 65.
Error: Process completed with exit code 65.
```