### PR TITLE
Stop notarizing concurrency framework

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -133,12 +133,6 @@ jobs:
           xcrun notarytool submit helper.zip --keychain-profile "notarytool-profile" --wait
           xcrun stapler staple "build/Release/WakaTime.app/Contents/Library/LoginItems/WakaTime Helper.app"
       -
-        name: Notarize libswift_Concurrency.dylib
-        run: |
-          ditto -c -k --keepParent build/Release/WakaTime.app/Contents/Frameworks/libswift_Concurrency.dylib concurrency.zip
-          xcrun notarytool submit concurrency.zip --keychain-profile "notarytool-profile" --wait
-          xcrun stapler staple build/Release/WakaTime.app/Contents/Frameworks/libswift_Concurrency.dylib
-      -
         name: Notarize App
         run: |
           ditto -c -k --keepParent build/Release/WakaTime.app main.zip

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ To fix linter warning(s), run `swiftlint --fix`.
 
 Pull requests and issues are welcome!
 See [Contributing][contributing] for more details.
+The main thing to know is we require specific branch name prefixes for PRs:
+
+- `^major/.+` - `major`
+- `^feature/.+` - `minor`
+- `^bugfix/.+` - `patch`
+- `^docs?/.+` - `build`
+- `^misc/.+` - `build`
 
 Many thanks to all [contributors][authors]!
 


### PR DESCRIPTION
To fix https://github.com/wakatime/macos-wakatime/actions/runs/5258201829/jobs/9502147379:

```
Current status: In Progress.....
Current status: Accepted......Processing complete
  id: a5e96120-9e49-461d-ac77-d984aa79e079
  status: Accepted

Processing: /Users/runner/work/macos-wakatime/macos-wakatime/build/Release/WakaTime.app/Contents/Frameworks/libswift_Concurrency.dylib
The staple and validate action failed! Error 73.
Error: Process completed with exit code 73.
```