### PR TITLE
Run release step on macos

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -151,7 +151,7 @@ jobs:
 
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     needs: [version, sign]
     steps:
       -


### PR DESCRIPTION
To fix `./bin/sparkle/generate_appcast: cannot execute binary file: Exec format error`