### PR TITLE
Watch filesystem events noop

### DIFF
--- a/WakaTime/Watcher.swift
+++ b/WakaTime/Watcher.swift
@@ -1,3 +1,4 @@
+import EonilFSEvents
 import Foundation
 import AppKit
 
@@ -34,10 +35,23 @@ class Watcher: NSObject {
             matching: [NSEvent.EventTypeMask.keyDown],
             handler: handleKeyboardEvent
         )
+
+        do {
+            try EonilFSEvents.startWatching(
+                paths: ["/"],
+                for: ObjectIdentifier(self),
+                with: { event in
+                    // print(event)
+                }
+            )
+        } catch {
+            NSLog("Failed to setup FSEvents: \(error.localizedDescription)")
+        }
     }
 
     deinit {
         NSWorkspace.shared.notificationCenter.removeObserver(self) // needed prior macOS 11 only
+        EonilFSEvents.stopWatching(for: ObjectIdentifier(self))
     }
 
     @objc private func appChanged(_ notification: Notification) {

--- a/project.yml
+++ b/project.yml
@@ -8,6 +8,9 @@ packages:
   Sparkle:
     url: https://github.com/sparkle-project/Sparkle
     from: 2.0.0
+  EonilFSEvents:
+    url: https://github.com/eonil/FSEvents
+    from: 0.1.7
 
 targets:
   WakaTime:
@@ -31,6 +34,7 @@ targets:
     dependencies:
       - target: WakaTime Helper
       - package: Sparkle
+      - package: EonilFSEvents
     postBuildScripts:
       - script: |
           LOGIN_ITEMS_DIR="$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.app/Contents/Library/LoginItems"


### PR DESCRIPTION
Starts work towards #103, but running into a problem:

There are too many FSEvents from background apps not currently focused. We need a way to filter only FSEvents from the currently focused application.