### PR TITLE
Remove scheme when building

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -23,7 +23,7 @@ jobs:
         run: xcodegen
       -
         name: Build app to run linters
-        run: xcodebuild -scheme WakaTime
+        run: xcodebuild
 
   version:
     name: Version
@@ -98,7 +98,7 @@ jobs:
         run: xcodegen
       -
         name: Build app
-        run: xcodebuild -scheme WakaTime -configuration Release
+        run: xcodebuild -configuration Release
       -
         name: Import Code-Signing Certificates
         uses: Apple-Actions/import-codesign-certs@v1


### PR DESCRIPTION
Fixes signing because `-scheme WakaTime` builds `Debug` and we want `Release`.