### PR TITLE
Upgrade Sparkle to v2.5.0-beta.1

### DIFF
--- a/WakaTime/WakaTime-Info.plist
+++ b/WakaTime/WakaTime-Info.plist
@@ -9,11 +9,13 @@
 	<key>SUPublicEDKey</key>
 	<string>6I/0TFjR4Fwf/dRPerG9McAsG5czi7yNBgW6usORg+g=</string>
 	<key>SUAllowsAutomaticUpdates</key>
-	<string>YES</string>
+	<true/>
 	<key>SUEnableAutomaticChecks</key>
-	<string>YES</string>
+	<true/>
+	<key>SUShowReleaseNotes</key>
+	<false/>
 	<key>SUAutomaticallyUpdate</key>
-	<string>YES</string>
+	<true/>
 	<key>LSUIElement</key>
 	<true/>
 	<key>CFBundleURLTypes</key>

--- a/project.yml
+++ b/project.yml
@@ -7,7 +7,7 @@ options:
 packages:
   Sparkle:
     url: https://github.com/sparkle-project/Sparkle
-    from: 2.0.0
+    from: 2.5.0-beta.1
   Firebase:
     url: https://github.com/firebase/firebase-ios-sdk
     from: 10.0.0


### PR DESCRIPTION
Let's see if this fixes gentle toast notifications when new updates are available.