### PR TITLE
Replace Sparkle with AppUpdater

### DIFF
--- a/WakaTime/Views/SettingsView.swift
+++ b/WakaTime/Views/SettingsView.swift
@@ -5,36 +5,11 @@ class SettingsView: NSView, NSTextFieldDelegate {
 
     var apiKey: String = ""
 
-    var automaticallyDownloadUpdates: Bool {
-        get {
-            PropertiesManager.shouldAutomaticallyDownloadUpdates
-        }
-
-        set {
-            PropertiesManager.shouldAutomaticallyDownloadUpdates = newValue
-
-            guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return }
-
-            appDelegate.updaterController.updater.automaticallyDownloadsUpdates = newValue
-        }
-    }
-
     // MARK: Controls
 
     lazy var launchAtLoginCheckbox: NSButton = {
         let checkbox = NSButton(checkboxWithTitle: "Launch at login", target: self, action: #selector(launchAtLoginCheckboxClicked))
         checkbox.state = PropertiesManager.shouldLaunchOnLogin ? .on : .off
-        checkbox.translatesAutoresizingMaskIntoConstraints = false
-        return checkbox
-    }()
-
-    lazy var automaticallyDownloadUpdatesCheckbox: NSButton = {
-        let checkbox = NSButton(
-            checkboxWithTitle: "Automatically download updates",
-            target: self,
-            action: #selector(automaticallyDownloadUpdatesClicked)
-        )
-        checkbox.state = automaticallyDownloadUpdates ? .on : .off
         checkbox.translatesAutoresizingMaskIntoConstraints = false
         return checkbox
     }()
@@ -86,7 +61,6 @@ class SettingsView: NSView, NSTextFieldDelegate {
         super.init(frame: .zero)
 
         addSubview(launchAtLoginCheckbox)
-        addSubview(automaticallyDownloadUpdatesCheckbox)
         addSubview(apiKeyLabel)
         addSubview(textField)
         addSubview(stackView)
@@ -112,10 +86,6 @@ class SettingsView: NSView, NSTextFieldDelegate {
         }
     }
 
-    @objc func automaticallyDownloadUpdatesClicked() {
-        automaticallyDownloadUpdates = automaticallyDownloadUpdatesCheckbox.state == .on
-    }
-
     @objc func saveButtonClicked() {
         ConfigFile.setSetting(section: "settings", key: "api_key", val: textField.stringValue)
         self.window?.close()
@@ -134,10 +104,7 @@ class SettingsView: NSView, NSTextFieldDelegate {
             launchAtLoginCheckbox.topAnchor.constraint(equalTo: topAnchor, constant: 20),
             launchAtLoginCheckbox.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
 
-            automaticallyDownloadUpdatesCheckbox.topAnchor.constraint(equalTo: launchAtLoginCheckbox.bottomAnchor, constant: 20),
-            automaticallyDownloadUpdatesCheckbox.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
-
-            apiKeyLabel.topAnchor.constraint(equalTo: automaticallyDownloadUpdatesCheckbox.bottomAnchor, constant: 20),
+            apiKeyLabel.topAnchor.constraint(equalTo: launchAtLoginCheckbox.bottomAnchor, constant: 20),
             apiKeyLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
 
             textField.topAnchor.constraint(equalTo: apiKeyLabel.bottomAnchor, constant: 10),

--- a/WakaTime/WakaTime-Info.plist
+++ b/WakaTime/WakaTime-Info.plist
@@ -4,18 +4,6 @@
 <dict>
 	<key>CFBundleIdentifier</key>
 	<string></string>
-	<key>SUFeedURL</key>
-	<string>https://github.com/wakatime/macos-wakatime/releases/latest/download/appcast.xml</string>
-	<key>SUPublicEDKey</key>
-	<string>6I/0TFjR4Fwf/dRPerG9McAsG5czi7yNBgW6usORg+g=</string>
-	<key>SUAllowsAutomaticUpdates</key>
-	<true/>
-	<key>SUEnableAutomaticChecks</key>
-	<true/>
-	<key>SUShowReleaseNotes</key>
-	<false/>
-	<key>SUAutomaticallyUpdate</key>
-	<true/>
 	<key>LSUIElement</key>
 	<true/>
 	<key>CFBundleURLTypes</key>

--- a/project.yml
+++ b/project.yml
@@ -5,9 +5,9 @@ options:
   createIntermediateGroups: true
 
 packages:
-  Sparkle:
-    url: https://github.com/sparkle-project/Sparkle
-    from: 2.5.0-beta.1
+  AppUpdater:
+    url: https://github.com/mxcl/AppUpdater
+    from: 1.1.1
   Firebase:
     url: https://github.com/firebase/firebase-ios-sdk
     from: 10.0.0
@@ -33,7 +33,7 @@ targets:
         name: Swiftlint
     dependencies:
       - target: WakaTime Helper
-      - package: Sparkle
+      - package: AppUpdater
       - package: Firebase
         product: FirebaseCrashlytics
     postBuildScripts:


### PR DESCRIPTION
Notifications of new updates has never worked with Sparkle, and Sparkle is unnecessarily complicated. This replaces Sparkle with [AppUpdater](https://github.com/mxcl/AppUpdater).

Leaving the appcast generation in-place for now, so old versions can still update manually by selecting `Check for updates` from the WakaTime system tray menu.