### PR TITLE
Truncate error alert and show version in up to date alert

### DIFF
--- a/WakaTime/AppDelegate.swift
+++ b/WakaTime/AppDelegate.swift
@@ -71,7 +71,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             if error.isCancelled {
                 let alert = NSAlert()
                 alert.messageText = "Up to date"
-                alert.informativeText = "You have the latest version."
+                alert.informativeText = "You have the latest version (\(Bundle.main.version))."
                 alert.alertStyle = NSAlert.Style.warning
                 alert.addButton(withTitle: "OK")
                 alert.runModal()
@@ -80,7 +80,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 NSLog(String(describing: error))
                 let alert = NSAlert()
                 alert.messageText = "Error"
-                alert.informativeText = error.localizedDescription
+                let max = 200
+                if error.localizedDescription.count <= max {
+                    alert.informativeText = error.localizedDescription
+                } else {
+                    alert.informativeText = String(error.localizedDescription.prefix(max).appending("…"))
+                }
                 alert.alertStyle = NSAlert.Style.warning
                 alert.addButton(withTitle: "OK")
                 alert.runModal()


### PR DESCRIPTION
## Before

<img width="250" alt="Screenshot 2023-08-10 at 10 56 59 PM" src="https://github.com/wakatime/macos-wakatime/assets/522344/081d7b60-e583-45aa-91e4-3b560a662abe">

## After

<img width="262" alt="Screenshot 2023-08-10 at 11 02 59 PM" src="https://github.com/wakatime/macos-wakatime/assets/522344/d5c31418-2ccb-4569-94e3-f93a8bf27c2a">
