### PR TITLE
Strip whitespace from plugin name and version

### DIFF
--- a/WakaTime/Helpers/AppInfo.swift
+++ b/WakaTime/Helpers/AppInfo.swift
@@ -20,6 +20,11 @@ class AppInfo {
         return getAppName(bundleId: bundleId)
     }
 
+    static func getAppNameForHeartbeat(_ app: NSRunningApplication) -> String? {
+        guard let appName = getAppName(app) else { return nil }
+        return appName.filter { !$0.isWhitespace }
+    }
+
     static func getIcon(file path: String) -> NSImage? {
         guard
             FileManager.default.fileExists(atPath: path)

--- a/WakaTime/WakaTime.swift
+++ b/WakaTime/WakaTime.swift
@@ -106,7 +106,7 @@ class WakaTime: HeartbeatEventHandler {
         guard MonitoringManager.isAppMonitored(app) else { return }
 
         guard
-            let appName = AppInfo.getAppName(app),
+            let appName = AppInfo.getAppNameForHeartbeat(app),
             let appVersion = watcher.getAppVersion(app)
         else { return }
 

--- a/WakaTime/Watcher.swift
+++ b/WakaTime/Watcher.swift
@@ -90,8 +90,7 @@ class Watcher: NSObject {
             let bundle = Bundle(url: url)
         else { return }
 
-        let version = "\(bundle.version)-\(bundle.build)"
-        appVersions[id] = version
+        appVersions[id] = "\(bundle.version)-\(bundle.build)".filter { !$0.isWhitespace }
     }
 
     public func getAppVersion(_ app: NSRunningApplication) -> String? {


### PR DESCRIPTION
So the WakaTime API can correctly parse editor name from `User-Agent` string.