### PR TITLE
Add Linear, Notes, Notion, WeChat Work

### DIFF
--- a/WakaTime/Extensions/AXUIElementExtension.swift
+++ b/WakaTime/Extensions/AXUIElementExtension.swift
@@ -73,6 +73,15 @@ extension AXUIElement {
             case .iterm2:
                 guard let title = extractPrefix(rawTitle, separator: " - ") else { return nil }
                 return title
+            case .linear:
+                guard let title = extractPrefix(rawTitle, separator: " - ") else { return nil }
+                return title
+            case .notes:
+                guard let title = extractPrefix(rawTitle, separator: " - ") else { return nil }
+                return title
+            case .notion:
+                guard let title = extractPrefix(rawTitle, separator: " - ") else { return nil }
+                return title
             case .postman:
                 guard
                     let title = extractPrefix(rawTitle, separator: " - ", fullTitle: true),
@@ -108,11 +117,14 @@ extension AXUIElement {
                     title != "Warp"
                 else { return nil }
                 return title
+            case .wecom:
+                guard let title = extractPrefix(rawTitle, separator: " - ") else { return nil }
+                return title
             case .whatsapp:
                 guard let title = extractPrefix(rawTitle, separator: " - ") else { return nil }
                 return title
             case .xcode:
-                fatalError("Xcode should never use window title as entity")
+                fatalError("\(app.rawValue) should never use window title as entity")
             case .zoom:
                 guard let title = extractPrefix(rawTitle, separator: " - ") else { return nil }
                 return title

--- a/WakaTime/Extensions/NSRunningApplicationExtension.swift
+++ b/WakaTime/Extensions/NSRunningApplicationExtension.swift
@@ -7,6 +7,9 @@ enum MonitoredApp: String, CaseIterable {
     case figma = "com.figma.Desktop"
     case imessage = "com.apple.MobileSMS"
     case iterm2 = "com.googlecode.iterm2"
+    case linear = "com.linear"
+    case notes = "com.apple.Notes"
+    case notion = "notion.id"
     case postman = "com.postmanlabs.mac"
     case safari = "com.apple.Safari"
     case safaripreview = "com.apple.SafariTechnologyPreview"
@@ -14,6 +17,7 @@ enum MonitoredApp: String, CaseIterable {
     case tableplus = "com.tinyapp.TablePlus"
     case terminal = "com.apple.Terminal"
     case warp = "dev.warp.Warp-Stable"
+    case wecom = "com.tencent.WeWorkMac"
     case whatsapp = "net.whatsapp.WhatsApp"
     case xcode = "com.apple.dt.Xcode"
     case zoom = "us.zoom.xos"
@@ -39,6 +43,9 @@ enum MonitoredApp: String, CaseIterable {
         MonitoredApp.figma.rawValue,
         MonitoredApp.imessage.rawValue,
         MonitoredApp.iterm2.rawValue,
+        MonitoredApp.linear.rawValue,
+        MonitoredApp.notes.rawValue,
+        MonitoredApp.notion.rawValue,
         MonitoredApp.postman.rawValue,
         MonitoredApp.slack.rawValue,
         MonitoredApp.safari.rawValue,

--- a/WakaTime/Helpers/MonitoringManager.swift
+++ b/WakaTime/Helpers/MonitoringManager.swift
@@ -80,6 +80,18 @@ class MonitoringManager {
                 return HeartbeatData(
                     entity: title,
                     category: .coding)
+            case .linear:
+                return HeartbeatData(
+                    entity: title,
+                    category: .planning)
+            case .notes:
+                return HeartbeatData(
+                    entity: title,
+                    category: .learning)
+            case .notion:
+                return HeartbeatData(
+                    entity: title,
+                    category: .learning)
             case .postman:
                 return HeartbeatData(
                     entity: title,
@@ -109,12 +121,16 @@ class MonitoringManager {
                 return HeartbeatData(
                     entity: title,
                     category: .coding)
+            case .wecom:
+                return HeartbeatData(
+                    entity: title,
+                    category: .communicating)
             case .whatsapp:
                 return HeartbeatData(
                     entity: title,
                     category: .meeting)
             case .xcode:
-                fatalError("Xcode should never use window title")
+                fatalError("\(monitoredApp.rawValue) should never use window title")
             case .zoom:
                 return HeartbeatData(
                     entity: title,

--- a/WakaTime/Watcher.swift
+++ b/WakaTime/Watcher.swift
@@ -66,7 +66,9 @@ class Watcher: NSObject {
 
     private func handleAppChanged(_ app: NSRunningApplication) {
         if app != activeApp {
-            NSLog("App changed from \(activeApp?.localizedName ?? "nil") to \(app.localizedName ?? "nil")")
+            // swiftlint:disable line_length
+            NSLog("App changed from \(activeApp?.localizedName ?? "nil") to \(app.localizedName ?? "nil") (\(app.bundleIdentifier ?? "nil"))")
+            // swiftlint:enable line_length
             if let oldApp = activeApp { unwatch(app: oldApp) }
             activeApp = app
             if let bundleId = app.bundleIdentifier, MonitoringManager.isAppMonitored(for: bundleId) {


### PR DESCRIPTION
Adding these apps for #205 and #206 to the `Monitored Apps` menu, but they don't [yet track activity](https://github.com/wakatime/macos-wakatime/issues/205#issuecomment-1961074165).