### PR TITLE
Make sure entity not empty string

### DIFF
--- a/WakaTime/WakaTime.swift
+++ b/WakaTime/WakaTime.swift
@@ -79,12 +79,10 @@ class WakaTime: HeartbeatEventHandler {
     // MARK: Watcher Event Handling
 
     private func shouldSendHeartbeat(entity: String, time: Int, isWrite: Bool, category: Category) -> Bool {
-        guard
-            !isWrite,
-            category == lastCategory,
-            entity == lastEntity,
-            lastTime + 120 > time
-        else { return true }
+        if isWrite { return true }
+        if category != lastCategory { return true }
+        if !entity.isEmpty && entity != lastEntity { return true }
+        if lastTime + 120 < time { return true }
 
         return false
     }


### PR DESCRIPTION
Just to make sure we never execute `wakatime-cli` with an empty entity (`wakatime-cli --entity ""`) to prevent [these log messages](https://github.com/wakatime/macos-wakatime/issues/208#issuecomment-1975754116).