### PR TITLE
Hide un-suported apps from Monitored Apps menu

### DIFF
--- a/WakaTime/Extensions/NSRunningApplicationExtension.swift
+++ b/WakaTime/Extensions/NSRunningApplicationExtension.swift
@@ -54,6 +54,13 @@ enum MonitoredApp: String, CaseIterable {
         MonitoredApp.terminal.rawValue,
         MonitoredApp.warp.rawValue,
     ]
+
+    // list apps which we aren't yet able to track, so they're hidden from the Monitored Apps menu
+    static let unsuportedAppIds = [
+        MonitoredApp.linear.rawValue,
+        MonitoredApp.notes.rawValue,
+        MonitoredApp.notion.rawValue,
+    ]
 }
 
 extension NSRunningApplication {

--- a/WakaTime/Helpers/MonitoringManager.swift
+++ b/WakaTime/Helpers/MonitoringManager.swift
@@ -13,6 +13,11 @@ class MonitoringManager {
             MonitoredApp.allBundleIds.contains(bundleId.replacingOccurrences(of: "-setapp$", with: "", options: .regularExpression))
         else { return false }
 
+        guard
+            !MonitoredApp.unsuportedAppIds.contains(bundleId),
+            !MonitoredApp.unsuportedAppIds.contains(bundleId.replacingOccurrences(of: "-setapp$", with: "", options: .regularExpression))
+        else { return false }
+
         let isMonitoredKey = monitoredKey(bundleId: bundleId)
 
         if UserDefaults.standard.string(forKey: isMonitoredKey) != nil {


### PR DESCRIPTION
We can't actually track some apps yet, because none of the [AXObserver events](https://github.com/wakatime/macos-wakatime/blob/main/WakaTime/Watcher.swift#L117) are triggered for these apps so we don't know when they're being used or just idle.

Related to #205, #206, #194.