### PR TITLE
Fix toggle switch in Monitored Apps setting screen

### DIFF
--- a/WakaTime/Extensions/NSRunningApplicationExtension.swift
+++ b/WakaTime/Extensions/NSRunningApplicationExtension.swift
@@ -55,6 +55,19 @@ enum MonitoredApp: String, CaseIterable {
         MonitoredApp.warp.rawValue,
     ]
 
+    // list apps which are enabled by default on first run
+    static let defaultEnabledApps = [
+        MonitoredApp.canva.rawValue,
+        MonitoredApp.figma.rawValue,
+        MonitoredApp.linear.rawValue,
+        MonitoredApp.notes.rawValue,
+        MonitoredApp.notion.rawValue,
+        MonitoredApp.postman.rawValue,
+        MonitoredApp.tableplus.rawValue,
+        MonitoredApp.xcode.rawValue,
+        MonitoredApp.zoom.rawValue,
+    ]
+
     // list apps which we aren't yet able to track, so they're hidden from the Monitored Apps menu
     static let unsuportedAppIds = [
         MonitoredApp.linear.rawValue,

--- a/WakaTime/Helpers/MonitoringManager.swift
+++ b/WakaTime/Helpers/MonitoringManager.swift
@@ -21,13 +21,12 @@ class MonitoringManager {
         let isMonitoredKey = monitoredKey(bundleId: bundleId)
 
         if UserDefaults.standard.string(forKey: isMonitoredKey) != nil {
-            let isMonitored = UserDefaults.standard.bool(forKey: isMonitoredKey)
-            return isMonitored
+            return UserDefaults.standard.bool(forKey: isMonitoredKey)
         } else {
             UserDefaults.standard.set(false, forKey: isMonitoredKey)
             UserDefaults.standard.synchronize()
+            return false
         }
-        return true
     }
 
     static func isAppMonitored(_ app: NSRunningApplication) -> Bool {
@@ -147,6 +146,16 @@ class MonitoringManager {
         UserDefaults.standard.set(monitoringState == .on, forKey: monitoredKey(bundleId: bundleId))
         UserDefaults.standard.synchronize()
         // NSLog("Monitoring \(monitoringState == .on ? "enabled" : "disabled") for \(AppInfo.getAppName(bundleId: bundleId) ?? "")")
+    }
+
+    static func enableByDefault(_ bundleId: String) {
+        if AppInfo.getIcon(bundleId: bundleId) != nil && AppInfo.getAppName(bundleId: bundleId) != nil {
+            MonitoringManager.set(monitoringState: .on, for: bundleId)
+        }
+        let setAppId = bundleId.appending("-setapp")
+        if AppInfo.getIcon(bundleId: setAppId) != nil && AppInfo.getAppName(bundleId: setAppId) != nil {
+            MonitoringManager.set(monitoringState: .on, for: setAppId)
+        }
     }
 
     static func monitoredKey(bundleId: String) -> String {

--- a/WakaTime/WakaTime.swift
+++ b/WakaTime/WakaTime.swift
@@ -45,6 +45,9 @@ class WakaTime: HeartbeatEventHandler {
         }
 
         if !PropertiesManager.hasLaunchedBefore {
+            for bundleId in MonitoredApp.defaultEnabledApps {
+                MonitoringManager.enableByDefault(bundleId)
+            }
             PropertiesManager.hasLaunchedBefore = true
         }
     }


### PR DESCRIPTION
The `NSSwitch.tag` attribute was necessary to identify the bundleId from clicks.