### PR TITLE
Implement logging to a file

### DIFF
--- a/WakaTime Helper/AppDelegate.swift
+++ b/WakaTime Helper/AppDelegate.swift
@@ -6,26 +6,35 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
+        let userHome = FileManager.default.homeDirectoryForCurrentUser.pathComponents
+        let logFilePath = NSString.path(withComponents: userHome + [".wakatime", "macos-wakatime-helper.log"])
+        Logging.default.configure(filePath: logFilePath)
+
+        Logging.default.log("Starting WakaTime Helper")
+
         let runningApps = NSWorkspace.shared.runningApplications
         let isRunning = runningApps.contains {
             $0.bundleIdentifier == Constants.mainAppBundleID
         }
 
         if !isRunning {
+            Logging.default.log("WakaTime is not running")
             var path = Bundle.main.bundlePath as NSString
             for _ in 1...4 {
                 path = path.deletingLastPathComponent as NSString
             }
             let fileURL = URL(fileURLWithPath: path as String)
-            NSLog("Opening", fileURL.absoluteString)
+            Logging.default.log("Attempting to open WakaTime at \"\(fileURL.absoluteString)\"")
             NSWorkspace.shared.openApplication(
                 at: fileURL,
                 configuration: NSWorkspace.OpenConfiguration()
             ) { _, error in
                 if let error {
-                    NSLog(error.localizedDescription)
+                    Logging.default.log(error.localizedDescription)
                 }
             }
+        } else {
+            Logging.default.log("WakaTime is already running")
         }
     }
 }

--- a/WakaTime Helper/Logging.swift
+++ b/WakaTime Helper/Logging.swift
@@ -1,0 +1,37 @@
+import Foundation
+import os.log
+
+class Logging {
+    static let `default` = Logging()
+    private var filePath: String?
+
+    private init() {}
+
+    // Configures logging to also write to a file at the given path.
+    func configure(filePath: String) {
+        self.filePath = filePath
+    }
+
+    func log(_ message: String, type: OSLogType = .default) {
+        os_log("%{public}@", log: .default, type: type, message)
+
+        if let filePath = self.filePath {
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+            let timestamp = dateFormatter.string(from: Date())
+            let logMessage = "\(timestamp): \(message)\n"
+
+            // Attempt to append the log message to the log file
+            if let fileHandle = FileHandle(forWritingAtPath: filePath) {
+                fileHandle.seekToEndOfFile()
+                if let data = logMessage.data(using: .utf8) {
+                    fileHandle.write(data)
+                }
+                fileHandle.closeFile()
+            } else {
+                // If the file does not exist, create it
+                try? logMessage.write(toFile: filePath, atomically: true, encoding: .utf8)
+            }
+        }
+    }
+}

--- a/WakaTime/AppDelegate.swift
+++ b/WakaTime/AppDelegate.swift
@@ -15,6 +15,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, StatusBarDelegate {
     let updater = AppUpdater(owner: "wakatime", repo: "macos-wakatime")
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
+        // Configure logging to a log file if activated by the user
+        if PropertiesManager.shouldLogToFile {
+            Logging.default.activateLoggingToFile()
+        }
+
+        Logging.default.log("Starting WakaTime")
+
         // Handle deep links
         let eventManager = NSAppleEventManager.shared()
         eventManager.setEventHandler(
@@ -54,11 +61,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, StatusBarDelegate {
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { granted, error in
             guard granted else {
                 if let msg = error?.localizedDescription {
-                    NSLog(msg)
+                    Logging.default.log(msg)
                 }
                 return
             }
         }
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        Logging.default.log("WakaTime will terminate")
     }
 
     @objc func handleGetURL(_ event: NSAppleEventDescriptor, withReplyEvent replyEvent: NSAppleEventDescriptor) {
@@ -103,7 +114,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, StatusBarDelegate {
                 alert.addButton(withTitle: "OK")
                 alert.runModal()
             } else {
-                NSLog(String(describing: error))
+                Logging.default.log(String(describing: error))
                 let alert = NSAlert()
                 alert.messageText = "Error"
                 let max = 200

--- a/WakaTime/ConfigFile.swift
+++ b/WakaTime/ConfigFile.swift
@@ -23,7 +23,7 @@ struct ConfigFile {
         do {
             contents = try String(contentsOfFile: file)
         } catch {
-            NSLog("Failed reading \(file): " + error.localizedDescription)
+            Logging.default.log("Failed reading \(file): " + error.localizedDescription)
             return nil
         }
         let lines = contents.split(separator: "\n")

--- a/WakaTime/Extensions/AXObserverExtension.swift
+++ b/WakaTime/Extensions/AXObserverExtension.swift
@@ -14,31 +14,31 @@ extension AXObserver {
     func add(notification: String, element: AXUIElement, refcon: UnsafeMutableRawPointer?) throws {
         let error = AXObserverAddNotification(self, element, notification as CFString, refcon)
         guard error == .success else {
-            NSLog("Add notification \(notification) failed: \(error.rawValue)")
+            Logging.default.log("Add notification \(notification) failed: \(error.rawValue)")
             throw AXObserverError.addNotificationFailed(error)
         }
 
-        // NSLog("Added notification \(notification) to observer \(self)")
+        // Logging.default.log("Added notification \(notification) to observer \(self)")
     }
 
     func remove(notification: String, element: AXUIElement) throws {
         let error = AXObserverRemoveNotification(self, element, notification as CFString)
         guard error == .success else {
-            NSLog("Remove notification \(notification) failed: \(error.rawValue)")
+            Logging.default.log("Remove notification \(notification) failed: \(error.rawValue)")
             throw AXObserverError.removeNotificationFailed(error)
         }
 
-        // NSLog("Removed notification \(notification) from observer \(self)")
+        // Logging.default.log("Removed notification \(notification) from observer \(self)")
     }
 
     func addToRunLoop(mode: CFRunLoopMode = .defaultMode) {
         CFRunLoopAddSource(RunLoop.current.getCFRunLoop(), AXObserverGetRunLoopSource(self), mode)
-        // NSLog("Added observer \(self) to run loop")
+        // Logging.default.log("Added observer \(self) to run loop")
     }
 
     func removeFromRunLoop(mode: CFRunLoopMode = .defaultMode) {
         CFRunLoopRemoveSource(RunLoop.current.getCFRunLoop(), AXObserverGetRunLoopSource(self), mode)
-        // NSLog("Removed observer \(self) from run loop")
+        // Logging.default.log("Removed observer \(self) from run loop")
     }
 }
 

--- a/WakaTime/Extensions/AXUIElementExtension.swift
+++ b/WakaTime/Extensions/AXUIElementExtension.swift
@@ -259,7 +259,7 @@ extension AXUIElement {
                 let isMultiline = child.value?.contains("\n") ?? false
                 let displayValue = isMultiline ? "[multiple lines]" : (child.value?.components(separatedBy: .newlines).first ?? "?")
                 let ellipsedValue = displayValue.count > 50 ? String(displayValue.prefix(47)) + "..." : displayValue
-                print(
+                Logging.default.log(
                     "\(indentation)Role: \(child.role ?? "?"), " +
                     "Subrole: \(child.subrole ?? "?"), " +
                     "Title: \(child.rawTitle ?? "?"), " +
@@ -274,7 +274,7 @@ extension AXUIElement {
         let isMultiline = value?.contains("\n") ?? false
         let displayValue = isMultiline ? "[multiple lines]" : (value?.components(separatedBy: .newlines).first ?? "?")
         let ellipsedValue = displayValue.count > 50 ? String(displayValue.prefix(47)) + "..." : displayValue
-        print(
+        Logging.default.log(
             "Role: \(role ?? "?"), " +
             "Subrole: \(subrole ?? "?"), " +
             "Title: \(rawTitle ?? "?"), " +

--- a/WakaTime/FileSavedWatcher.swift
+++ b/WakaTime/FileSavedWatcher.swift
@@ -8,7 +8,7 @@ class FileMonitor {
         self.fileURL = filePath
         let folderURL = fileURL.deletingLastPathComponent() // monitor enclosing folder to track changes by Xcode
         let descriptor = open(folderURL.path, O_EVTONLY)
-        guard descriptor >= -1 else { NSLog("open failed: \(descriptor)"); return nil }
+        guard descriptor >= -1 else { Logging.default.log("open failed: \(descriptor)"); return nil }
         dispatchObject = DispatchSource.makeFileSystemObjectSource(fileDescriptor: descriptor, eventMask: .write, queue: queue)
         dispatchObject?.setEventHandler { [weak self] in
             self?.fileChangedEventHandler?()

--- a/WakaTime/Helpers/Dependencies.swift
+++ b/WakaTime/Helpers/Dependencies.swift
@@ -85,7 +85,7 @@ class Dependencies {
             let now = Int(NSDate().timeIntervalSince1970)
             let fourHours = 4 * 3600
             if accessed + fourHours > now {
-                NSLog("Skip checking for wakatime-cli updates because recently checked \(now - accessed) seconds ago")
+                Logging.default.log("Skip checking for wakatime-cli updates because recently checked \(now - accessed) seconds ago")
                 return true
             }
         }
@@ -110,7 +110,7 @@ class Dependencies {
             do {
                 try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true, attributes: nil)
             } catch {
-                NSLog(error.localizedDescription)
+                Logging.default.log(error.localizedDescription)
             }
         }
 
@@ -123,7 +123,7 @@ class Dependencies {
             do {
                 try FileManager.default.removeItem(atPath: zipFile)
             } catch {
-                NSLog(error.localizedDescription)
+                Logging.default.log(error.localizedDescription)
                 return
             }
         }
@@ -139,7 +139,7 @@ class Dependencies {
                     do {
                         try FileManager.default.removeItem(atPath: cliReal)
                     } catch {
-                        NSLog(error.localizedDescription)
+                        Logging.default.log(error.localizedDescription)
                         return
                     }
                 }
@@ -163,7 +163,7 @@ class Dependencies {
                 try! FileManager.default.createSymbolicLink(atPath: cli, withDestinationPath: cliReal)
 
             } catch {
-                NSLog(error.localizedDescription)
+                Logging.default.log(error.localizedDescription)
             }
         }.resume()
     }

--- a/WakaTime/Helpers/PropertiesManager.swift
+++ b/WakaTime/Helpers/PropertiesManager.swift
@@ -3,9 +3,11 @@ import Foundation
 class PropertiesManager {
     enum Keys: String {
         case shouldLaunchOnLogin = "launch_on_login"
+        case shouldLogToFile = "log_to_file"
         case shouldAutomaticallyDownloadUpdates = "should_automatically_download_updates"
         case hasLaunchedBefore = "has_launched_before"
     }
+
     static var shouldLaunchOnLogin: Bool {
         get {
             guard UserDefaults.standard.string(forKey: Keys.shouldLaunchOnLogin.rawValue) != nil else {
@@ -18,6 +20,26 @@ class PropertiesManager {
         set {
             UserDefaults.standard.set(newValue, forKey: Keys.shouldLaunchOnLogin.rawValue)
             UserDefaults.standard.synchronize()
+        }
+    }
+
+    static var shouldLogToFile: Bool {
+        get {
+            guard UserDefaults.standard.string(forKey: Keys.shouldLogToFile.rawValue) != nil else {
+                UserDefaults.standard.set(false, forKey: Keys.shouldLogToFile.rawValue)
+                return false
+            }
+
+            return UserDefaults.standard.bool(forKey: Keys.shouldLogToFile.rawValue)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: Keys.shouldLogToFile.rawValue)
+            UserDefaults.standard.synchronize()
+            if newValue {
+                Logging.default.activateLoggingToFile()
+            } else {
+                Logging.default.deactivateLoggingToFile()
+            }
         }
     }
 

--- a/WakaTime/Helpers/SettingsManager.swift
+++ b/WakaTime/Helpers/SettingsManager.swift
@@ -33,15 +33,15 @@ class SettingsManager {
         if #available(macOS 13.0, *), !simulateOldMacOS {
             do {
                 try SMAppService.mainApp.register()
-                NSLog("Registered for login")
+                Logging.default.log("Registered for login")
             } catch let error {
-                NSLog(error.localizedDescription)
+                Logging.default.log(error.localizedDescription)
             }
         } else {
             if SMLoginItemSetEnabled("macos-wakatime.WakaTimeHelper" as CFString, true) {
-                NSLog("Login item enabled successfully.")
+                Logging.default.log("Login item enabled successfully.")
             } else {
-                NSLog("Failed to enable login item.")
+                Logging.default.log("Failed to enable login item.")
             }
         }
     }
@@ -52,15 +52,15 @@ class SettingsManager {
         if #available(macOS 13.0, *), !simulateOldMacOS {
             do {
                 try SMAppService.mainApp.unregister()
-                NSLog("Unregistered for login")
+                Logging.default.log("Unregistered for login")
             } catch let error {
-                NSLog(error.localizedDescription)
+                Logging.default.log(error.localizedDescription)
             }
         } else {
             if SMLoginItemSetEnabled("macos-wakatime.WakaTimeHelper" as CFString, false) {
-                NSLog("Login item disabled successfully.")
+                Logging.default.log("Login item disabled successfully.")
             } else {
-                NSLog("Failed to disable login item.")
+                Logging.default.log("Failed to disable login item.")
             }
         }
     }

--- a/WakaTime/Utils/Logging.swift
+++ b/WakaTime/Utils/Logging.swift
@@ -1,0 +1,47 @@
+import Foundation
+import os.log
+
+class Logging {
+    static let `default` = Logging()
+    private var filePath: String?
+
+    private init() {}
+
+    // Configures logging to also write to a file at the given path.
+    func configure(filePath: String) {
+        self.filePath = filePath
+    }
+
+    func activateLoggingToFile() {
+        let userHome = FileManager.default.homeDirectoryForCurrentUser.pathComponents
+        let logFilePath = NSString.path(withComponents: userHome + [".wakatime", "macos-wakatime.log"])
+        configure(filePath: logFilePath)
+    }
+
+    func deactivateLoggingToFile() {
+        filePath = nil
+    }
+
+    func log(_ message: String, type: OSLogType = .default) {
+        os_log("%{public}@", log: .default, type: type, message)
+
+        if let filePath {
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+            let timestamp = dateFormatter.string(from: Date())
+            let logMessage = "\(timestamp): \(message)\n"
+
+            // Attempt to append the log message to the log file
+            if let fileHandle = FileHandle(forWritingAtPath: filePath) {
+                fileHandle.seekToEndOfFile()
+                if let data = logMessage.data(using: .utf8) {
+                    fileHandle.write(data)
+                }
+                fileHandle.closeFile()
+            } else {
+                // If the file does not exist, create it
+                try? logMessage.write(toFile: filePath, atomically: true, encoding: .utf8)
+            }
+        }
+    }
+}

--- a/WakaTime/Views/SettingsView.swift
+++ b/WakaTime/Views/SettingsView.swift
@@ -10,6 +10,17 @@ class SettingsView: NSView, NSTextFieldDelegate {
         return checkbox
     }()
 
+    lazy var enableLoggingCheckbox: NSButton = {
+        let checkbox = NSButton(
+            checkboxWithTitle: "Enable loggin to ~/.wakatime/macos-wakatime.log",
+            target: self,
+            action: #selector(enableLoggingCheckboxClicked)
+        )
+        checkbox.state = PropertiesManager.shouldLogToFile ? .on : .off
+        checkbox.translatesAutoresizingMaskIntoConstraints = false
+        return checkbox
+    }()
+
     lazy var apiKeyLabel: NSTextField = {
         let apiKeyLabel = NSTextField(labelWithString: "WakaTime API Key:")
         apiKeyLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -35,6 +46,7 @@ class SettingsView: NSView, NSTextFieldDelegate {
         super.init(frame: .zero)
 
         addSubview(launchAtLoginCheckbox)
+        addSubview(enableLoggingCheckbox)
         addSubview(apiKeyLabel)
         addSubview(textField)
         addSubview(versionLabel)
@@ -55,6 +67,15 @@ class SettingsView: NSView, NSTextFieldDelegate {
         }
     }
 
+    @objc func enableLoggingCheckboxClicked() {
+        PropertiesManager.shouldLaunchOnLogin = enableLoggingCheckbox.state == .on
+        if enableLoggingCheckbox.state == .on {
+            PropertiesManager.shouldLogToFile = true
+        } else {
+            PropertiesManager.shouldLogToFile = false
+        }
+    }
+
     func controlTextDidChange(_ obj: Notification) {
         ConfigFile.setSetting(section: "settings", key: "api_key", val: textField.stringValue)
     }
@@ -64,7 +85,10 @@ class SettingsView: NSView, NSTextFieldDelegate {
             launchAtLoginCheckbox.topAnchor.constraint(equalTo: topAnchor, constant: 20),
             launchAtLoginCheckbox.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
 
-            apiKeyLabel.topAnchor.constraint(equalTo: launchAtLoginCheckbox.bottomAnchor, constant: 20),
+            enableLoggingCheckbox.topAnchor.constraint(equalTo: launchAtLoginCheckbox.bottomAnchor, constant: 10),
+            enableLoggingCheckbox.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
+
+            apiKeyLabel.topAnchor.constraint(equalTo: enableLoggingCheckbox.bottomAnchor, constant: 30),
             apiKeyLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
 
             textField.topAnchor.constraint(equalTo: apiKeyLabel.bottomAnchor, constant: 10),
@@ -74,7 +98,6 @@ class SettingsView: NSView, NSTextFieldDelegate {
             versionLabel.topAnchor.constraint(equalTo: textField.bottomAnchor, constant: 10),
             versionLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
             versionLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),
-            versionLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -20)
         ]
         NSLayoutConstraint.activate(constraints)
     }

--- a/WakaTime/WakaTime.swift
+++ b/WakaTime/WakaTime.swift
@@ -35,13 +35,13 @@ class WakaTime: HeartbeatEventHandler {
 
         // In local dev builds, print bundle-ids of all running apps to Xcode console
         if Dependencies.isLocalDevBuild {
-            print("********* Start Running Applications *********")
+            Logging.default.log("********* Start Running Applications *********")
             for runningApp in NSWorkspace.shared.runningApplications where runningApp.activationPolicy == .regular {
                 if let name = runningApp.localizedName, let id = runningApp.bundleIdentifier {
-                    print("\(name): \(id)")
+                    Logging.default.log("\(name): \(id)")
                 }
             }
-            print("********* End Running Applications *********")
+            Logging.default.log("********* End Running Applications *********")
         }
 
         if !PropertiesManager.hasLaunchedBefore {
@@ -138,7 +138,7 @@ class WakaTime: HeartbeatEventHandler {
             args.append(language)
         }
 
-        NSLog("Sending heartbeat with: \(args)")
+        Logging.default.log("Sending heartbeat with: \(args)")
 
         process.arguments = args
         process.standardOutput = FileHandle.nullDevice
@@ -148,7 +148,7 @@ class WakaTime: HeartbeatEventHandler {
             // with ObjC exception bridging on macOS 12 or earlier and Process.run() on macOS 13 or newer.
             try process.execute()
         } catch {
-            NSLog("Failed to run wakatime-cli: \(error)")
+            Logging.default.log("Failed to run wakatime-cli: \(error)")
         }
     }
 }

--- a/WakaTime/Watcher.swift
+++ b/WakaTime/Watcher.swift
@@ -76,11 +76,11 @@ class Watcher: NSObject {
                 paths: ["/"],
                 for: ObjectIdentifier(self),
                 with: { event in
-                    // NSLog(event)
+                    // Logging.default.log(event)
                 }
             )
         } catch {
-            NSLog("Failed to setup FSEvents: \(error.localizedDescription)")
+            Logging.default.log("Failed to setup FSEvents: \(error.localizedDescription)")
         }
         */
     }
@@ -98,7 +98,7 @@ class Watcher: NSObject {
     private func handleAppChanged(_ app: NSRunningApplication) {
         if app != activeApp {
             // swiftlint:disable line_length
-            NSLog("App changed from \(activeApp?.localizedName ?? "nil") to \(app.localizedName ?? "nil") (\(app.bundleIdentifier ?? "nil"))")
+            Logging.default.log("App changed from \(activeApp?.localizedName ?? "nil") to \(app.localizedName ?? "nil") (\(app.bundleIdentifier ?? "nil"))")
             // swiftlint:enable line_length
             if let oldApp = activeApp { unwatch(app: oldApp) }
             activeApp = app
@@ -141,7 +141,7 @@ class Watcher: NSObject {
                 let result = AXUIElementSetAttributeValue(axApp, "AXManualAccessibility" as CFString, true as CFTypeRef)
                 if result.rawValue != 0 {
                     let appName = app.localizedName ?? "UnknownApp"
-                    NSLog("Setting AXManualAccessibility on \(appName) failed (\(result.rawValue))")
+                    Logging.default.log("Setting AXManualAccessibility on \(appName) failed (\(result.rawValue))")
                 }
             }
 
@@ -168,7 +168,7 @@ class Watcher: NSObject {
                 observeActivityText(activeWindow: activeWindow)
             }
         } catch {
-            NSLog("Failed to setup AXObserver: \(error.localizedDescription)")
+            Logging.default.log("Failed to setup AXObserver: \(error.localizedDescription)")
 
             // TODO: App could be still launching, retry setting AXObserver in 20 seconds for this app
 
@@ -234,7 +234,7 @@ class Watcher: NSObject {
             if documentPath != oldValue {
                 guard let newPath = documentPath else { return }
 
-                NSLog("Document changed: \(newPath)")
+                Logging.default.log("Document changed: \(newPath)")
 
                 handleNotificationEvent(path: newPath, isWrite: false)
                 fileMonitor = nil
@@ -274,10 +274,6 @@ private func observerCallback(
 
     guard let app = this.activeApp else { return }
 
-    if Dependencies.isLocalDevBuild && !MonitoringManager.isAppXcode(app) {
-        // print(notification)
-        // element.debugPrint()
-    }
     let axNotification = AXUIElementNotification.notificationFrom(string: notification as String)
     switch axNotification {
         case .selectedTextChanged:

--- a/WakaTime/WindowControllers/SettingsWindowController.swift
+++ b/WakaTime/WindowControllers/SettingsWindowController.swift
@@ -7,7 +7,7 @@ class SettingsWindowController: NSWindowController, NSTextFieldDelegate {
         self.init(window: nil)
 
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 400, height: 150),
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 190),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false


### PR DESCRIPTION
Improvement for #219

Note: WakaTime Helper will always log to ~/.wakatime/macos-wakatime-helper.log regardless of the "Enable Logging" setting in the WakaTime app.