### PR TITLE
Prevent sending heartbeats too often

### DIFF
--- a/WakaTime/WakaTime.swift
+++ b/WakaTime/WakaTime.swift
@@ -101,10 +101,6 @@ class WakaTime: HeartbeatEventHandler {
         let category = category ?? Category.coding
         guard shouldSendHeartbeat(entity: entity, time: time, isWrite: isWrite, category: category) else { return }
 
-        lastEntity = entity
-        lastTime = time
-        lastCategory = category
-
         // make sure we should be tracking this app to avoid race condition bugs
         // do this after shouldSendHeartbeat for better performance because handleEvent may
         // be called frequently
@@ -139,6 +135,10 @@ class WakaTime: HeartbeatEventHandler {
         }
 
         Logging.default.log("Sending heartbeat with: \(args)")
+
+        lastEntity = entity
+        lastTime = time
+        lastCategory = category
 
         process.arguments = args
         process.standardOutput = FileHandle.nullDevice


### PR DESCRIPTION
This fixes a bug where switching from a monitored app to an un-monitored app then back to the monitored app would trigger a heartbeat, because `lastEntity` was set to the value from the un-monitored app. Instead, we should only set `lastEntity` from monitored apps to prevent sending heartbeats too frequently.