### PR TITLE
Make monitored apps scrollable

### DIFF
--- a/WakaTime/Views/MonitoredAppsView.swift
+++ b/WakaTime/Views/MonitoredAppsView.swift
@@ -50,9 +50,9 @@ class MonitoredAppsView: NSView, NSOutlineViewDataSource, NSOutlineViewDelegate 
 
         let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("AppColumn"))
         outlineView.addTableColumn(column)
-        outlineView.headerView = nil // Remove header if not needed
-
+        outlineView.headerView = nil
         outlineView.outlineTableColumn = column
+        outlineView.indentationPerLevel = 0.0
     }
 
     func reloadData() {
@@ -137,9 +137,9 @@ class MonitoredAppsView: NSView, NSOutlineViewDataSource, NSOutlineViewDelegate 
 
             nameLabel.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: 10),
             nameLabel.centerYAnchor.constraint(equalTo: cellView.centerYAnchor),
-            nameLabel.trailingAnchor.constraint(equalTo: switchControl.leadingAnchor, constant: -10),
+            nameLabel.trailingAnchor.constraint(equalTo: switchControl.leadingAnchor, constant: -5),
 
-            switchControl.trailingAnchor.constraint(equalTo: cellView.trailingAnchor, constant: -5),
+            switchControl.trailingAnchor.constraint(equalTo: cellView.trailingAnchor, constant: -10),
             switchControl.centerYAnchor.constraint(equalTo: cellView.centerYAnchor),
         ])
 

--- a/WakaTime/Views/MonitoredAppsView.swift
+++ b/WakaTime/Views/MonitoredAppsView.swift
@@ -85,6 +85,10 @@ class MonitoredAppsView: NSView, NSOutlineViewDataSource, NSOutlineViewDelegate 
 
     // MARK: NSOutlineViewDelegate
 
+    func outlineView(_ outlineView: NSOutlineView, shouldSelectItem item: Any) -> Bool {
+        false
+    }
+
     func outlineView(_ outlineView: NSOutlineView, heightOfRowByItem item: Any) -> CGFloat {
         50
     }

--- a/WakaTime/Views/MonitoredAppsView.swift
+++ b/WakaTime/Views/MonitoredAppsView.swift
@@ -4,18 +4,33 @@ class MonitoredAppsView: NSView {
     init() {
         super.init(frame: .zero)
 
+        let scrollView = NSScrollView(frame: .zero)
+        scrollView.hasVerticalScroller = true
+        scrollView.drawsBackground = false
+
         let stackView = NSStackView(frame: .zero)
         stackView.orientation = .vertical
         stackView.distribution = .equalSpacing
         stackView.alignment = .leading
+        stackView.spacing = 10
 
-        addSubview(stackView)
+        scrollView.documentView = stackView
+
+        addSubview(scrollView)
+
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 0).isActive = true
+        scrollView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: 0).isActive = true
+        scrollView.topAnchor.constraint(equalTo: topAnchor, constant: 0).isActive = true
+        scrollView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: 0).isActive = true
 
         stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 32).isActive = true
-        stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -32).isActive = true
-        stackView.topAnchor.constraint(equalTo: topAnchor, constant: 32).isActive = true
-        stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -32).isActive = true
+        stackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor).isActive = true
+        stackView.trailingAnchor.constraint(
+            equalTo: scrollView.trailingAnchor,
+            constant: 0
+        ).isActive = true
+        stackView.topAnchor.constraint(equalTo: scrollView.topAnchor).isActive = true
 
         buildView(stackView: stackView)
     }
@@ -25,6 +40,14 @@ class MonitoredAppsView: NSView {
     }
 
     func buildView(stackView: NSStackView) {
+        // Transparent spacer view for padding at the top
+        let topSpacerView = NSView()
+        topSpacerView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            topSpacerView.heightAnchor.constraint(equalToConstant: 10)
+        ])
+        stackView.addArrangedSubview(topSpacerView)
+
         for (index, bundleId) in MonitoredApp.allBundleIds.enumerated() {
             guard !MonitoredApp.unsupportedAppIds.contains(bundleId) else { continue }
 
@@ -35,7 +58,13 @@ class MonitoredAppsView: NSView {
                 bundleId: bundleId.appending("-setapp"))
         }
 
-        stackView.addArrangedSubview(NSView())
+        // Transparent spacer view for padding at the bottom
+        let bottomSpacerView = NSView()
+        bottomSpacerView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            bottomSpacerView.heightAnchor.constraint(equalToConstant: 10)
+        ])
+        stackView.addArrangedSubview(bottomSpacerView)
     }
 
     func buildViewForApp(index: Int, stackView: NSStackView, bundleId: String) {
@@ -46,9 +75,21 @@ class MonitoredAppsView: NSView {
 
         let currentStackView = NSStackView(frame: .zero)
         currentStackView.orientation = .horizontal
-        currentStackView.distribution = .gravityAreas
+        currentStackView.distribution = .fill
 
-        currentStackView.spacing = 32
+        let paddingLeading = NSView()
+        paddingLeading.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            paddingLeading.widthAnchor.constraint(equalToConstant: 20) // Left padding
+        ])
+
+        let paddingTrailing = NSView()
+        paddingTrailing.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            paddingTrailing.widthAnchor.constraint(equalToConstant: 20) // Right padding
+        ])
+
+        currentStackView.addArrangedSubview(paddingLeading)
 
         let imageView = NSImageView(frame: NSRect(x: 0, y: 0, width: 15, height: 15))
         imageView.image = image
@@ -67,11 +108,12 @@ class MonitoredAppsView: NSView {
         currentStackView.addArrangedSubview(nameLabel)
         currentStackView.addArrangedSubview(switchControl)
 
+        currentStackView.addArrangedSubview(paddingTrailing)
+
         stackView.addArrangedSubview(currentStackView)
         currentStackView.translatesAutoresizingMaskIntoConstraints = false
         currentStackView.leadingAnchor.constraint(equalTo: stackView.leadingAnchor).isActive = true
         currentStackView.trailingAnchor.constraint(equalTo: stackView.trailingAnchor).isActive = true
-        currentStackView.huggingPriority(for: .horizontal)
         nameLabel.widthAnchor.constraint(equalTo: currentStackView.widthAnchor, multiplier: 0.7, constant: 0).isActive = true
 
         let divider = NSView(frame: NSRect(x: 0, y: 0, width: stackView.frame.width, height: 1))

--- a/WakaTime/Views/MonitoredAppsView.swift
+++ b/WakaTime/Views/MonitoredAppsView.swift
@@ -23,7 +23,7 @@ class MonitoredAppsView: NSView, NSOutlineViewDataSource, NSOutlineViewDelegate 
             let setAppBundleId = bundleId.appending("-setapp")
             if let icon = AppInfo.getIcon(bundleId: setAppBundleId),
                let name = AppInfo.getAppName(bundleId: setAppBundleId) {
-                apps.append(AppData(bundleId: bundleId.appending("-setapp"), icon: icon, name: name, tag: index))
+                apps.append(AppData(bundleId: setAppBundleId, icon: icon, name: name, tag: index))
                 index += 1
             }
         }

--- a/WakaTime/Views/MonitoredAppsView.swift
+++ b/WakaTime/Views/MonitoredAppsView.swift
@@ -55,6 +55,10 @@ class MonitoredAppsView: NSView, NSOutlineViewDataSource, NSOutlineViewDelegate 
         outlineView.outlineTableColumn = column
     }
 
+    func reloadData() {
+        outlineView.reloadData()
+    }
+
     // MARK: NSOutlineViewDataSource
 
     func outlineView(_ outlineView: NSOutlineView, numberOfChildrenOfItem item: Any?) -> Int {
@@ -94,9 +98,10 @@ class MonitoredAppsView: NSView, NSOutlineViewDataSource, NSOutlineViewDelegate 
         let nameLabel = NSTextField(labelWithString: appData.name)
         nameLabel.translatesAutoresizingMaskIntoConstraints = false
 
+        let isMonitored = MonitoringManager.isAppMonitored(for: appData.bundleId)
         let switchControl = NSSwitch()
         switchControl.translatesAutoresizingMaskIntoConstraints = false
-        switchControl.state = MonitoringManager.isAppMonitored(for: appData.bundleId) ? .on : .off
+        switchControl.state = isMonitored ? .on : .off
         switchControl.target = self
         switchControl.action = #selector(switchToggled(_:))
         switchControl.tag = apps.firstIndex(of: appData) ?? -1

--- a/WakaTime/WindowControllers/MonitoredAppsWindowController.swift
+++ b/WakaTime/WindowControllers/MonitoredAppsWindowController.swift
@@ -7,7 +7,7 @@ class MonitoredAppsWindowController: NSWindowController {
         self.init(window: nil)
 
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 400, height: 150),
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 450),
             styleMask: [.titled, .closable, .resizable],
             backing: .buffered,
             defer: false

--- a/WakaTime/WindowControllers/MonitoredAppsWindowController.swift
+++ b/WakaTime/WindowControllers/MonitoredAppsWindowController.swift
@@ -17,4 +17,9 @@ class MonitoredAppsWindowController: NSWindowController {
         window.contentView = monitoredAppsView
         self.window = window
     }
+
+    override func showWindow(_ sender: Any?) {
+        monitoredAppsView.reloadData()
+        super.showWindow(sender)
+    }
 }


### PR DESCRIPTION
Closes #232.

After some fiddling with the stack views, I gave up and rewrote the whole view to use a proper `NSOutlineView`, which is pretty standard on macOS. This one correctly adapts to the scroller visibility, which can be tricky on macOS and is hard to work out if you do your own customer `NSScrollView` with stack views setup.

What is more, there was a bug where, on first app launch, the Monitored Apps window would display all apps as disabled, even though the default apps were enabled (race condition) via `MonitoringManager.enableByDefault`.

I had a hard time understanding the following in the old code and I **didn't overtake it** to the new code. Please let me know if we need this and what it's supposed to do:

```
    @objc func switchToggled(_ sender: NSSwitch) {
        let isSetApp = !sender.tag.isMultiple(of: 2)
        let index = (isSetApp ? sender.tag - 1 : sender.tag) / 2
        var bundleId = MonitoredApp.allBundleIds[index]

        if isSetApp {
            bundleId = bundleId.appending("-setapp")
        }

        MonitoringManager.set(monitoringState: sender.state == .on ? .on : .off, for: bundleId)
    }
```

The new implementation just does this (which appears to be working fine):

```
    @objc func switchToggled(_ sender: NSSwitch) {
        guard sender.tag >= 0 && sender.tag < MonitoredApp.allBundleIds.count else { return }
        let bundleId = apps[sender.tag].bundleId
        MonitoringManager.set(monitoringState: sender.state == .on ? .on : .off, for: bundleId)
    }
```