### PR TITLE
Prevent upgrading wakatime-cli when built from source

### DIFF
--- a/WakaTime/Extensions/StringExtension.swift
+++ b/WakaTime/Extensions/StringExtension.swift
@@ -8,4 +8,8 @@ extension String {
         }
         return false
     }
+
+    func trim() -> String {
+        self.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+    }
 }

--- a/WakaTime/Helpers/Dependencies.swift
+++ b/WakaTime/Helpers/Dependencies.swift
@@ -71,6 +71,12 @@ class Dependencies {
         }
         let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
         let output = String(decoding: outputData, as: UTF8.self)
+
+        // disable updating wakatime-cli when it was built from source
+        if output.trim() == "<local-build>" {
+            return true
+        }
+
         let version: String?
         if let regex = try? NSRegularExpression(pattern: "([0-9]+\\.[0-9]+\\.[0-9]+)"),
            let match = regex.firstMatch(in: output, range: NSRange(output.startIndex..., in: output)),


### PR DESCRIPTION
When wakatime-cli was built from source code, disable updating wakatime-cli. The desktop app will still update automatically, just not wakatime-cli.