### PR TITLE
Support for Zed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,17 @@
 # Contributing
 
-To contribute to this project please carefully read this document.
-
 ## Setup
 
-`macos-wakatime` is written in [Swift](https://www.swift.org/).
+This project depends on the [xcodegen](https://github.com/yonaskolb/XcodeGen?tab=readme-ov-file#installing) command line tool.
+
+```bash
+git clone git@github.com:wakatime/macos-wakatime.git
+cd macos-wakatime
+xcodegen
+```
+
+Then open the `WakaTime.xcodeproj` in [Xcode 15.2](https://developer.apple.com/services-account/download?path=/Developer_Tools/Xcode_15.2/Xcode_15.2.xip).
+Currently there’s a bug in new Swift compiler versions, so the largest Xcode version working with this app is 15.2.
 
 ## Branches
 
@@ -23,7 +30,15 @@ To fix linter warning(s), run `swiftlint --fix`.
 
 ## Branching Stratgegy
 
-Please follow our guideline for branch names [here](https://github.com/wakatime/semver-action#branch-names). Branches off the pattern won't be accepted.
+We require specific branch name prefixes for PRs:
+
+- `^major/.+` - `major`
+- `^feature/.+` - `minor`
+- `^bugfix/.+` - `patch`
+- `^docs?/.+` - `build`
+- `^misc/.+` - `build`
+
+More info at [wakatime/semver-action](https://github.com/wakatime/semver-action#branch-names).
 
 ## Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,6 @@ Before requesting support for a new app, first check the [list of supported apps
 
 Pull requests and issues are welcome!
 See [Contributing][contributing] for more details.
-The main thing to know is we require specific branch name prefixes for PRs:
-
-- `^major/.+` - `major`
-- `^feature/.+` - `minor`
-- `^bugfix/.+` - `patch`
-- `^docs?/.+` - `build`
-- `^misc/.+` - `build`
-
 Many thanks to all [contributors][authors]!
 
 Made with :heart: by the WakaTime Team.

--- a/WakaTime/Extensions/AXUIElementExtension.swift
+++ b/WakaTime/Extensions/AXUIElementExtension.swift
@@ -369,24 +369,6 @@ extension AXUIElement {
             "Value: \"\(ellipsedValue)\""
         )
     }
-
-    func extractPrefix(_ str: String?, separator: String, minCount: Int? = nil, fullTitle: Bool = false) -> String? {
-        guard let str = str else { return nil }
-
-        let parts = str.components(separatedBy: separator)
-
-        if let minCount = minCount, minCount > 0, parts.count < minCount {
-            return nil
-        }
-
-        if !parts.isEmpty && parts[0].trimmingCharacters(in: .whitespacesAndNewlines) != "" {
-            if fullTitle {
-                return str.trimmingCharacters(in: .whitespacesAndNewlines)
-            }
-            return parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
-        }
-        return nil
-    }
 }
 
 enum AXUIElementNotification {


### PR DESCRIPTION
Using the window title from Zed, we get the currently open file name and project name. With just the file name (vs file path) we can't detect language, or other file stats. I'll look into ways to get the absolute file path of the focused file and submit a future PR if there's any solution.