### PR TITLE
Only support MacOS 14.5

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -16,7 +16,7 @@ targets:
   WakaTime:
     type: application
     platform: macOS
-    deploymentTarget: 10.15
+    deploymentTarget: 14.5
     sources: [WakaTime]
     settings:
       CURRENT_PROJECT_VERSION: local-build
@@ -51,7 +51,7 @@ targets:
   WakaTime Helper:
     type: application
     platform: macOS
-    deploymentTarget: 10.15
+    deploymentTarget: 14.5
     sources: [WakaTime Helper]
     settings:
       CURRENT_PROJECT_VERSION: local-build


### PR DESCRIPTION
To prevent warning:

```
You can’t open the application “WakaTime.app” because this application is not supported on this Mac
```