### PR TITLE
Fix releases for Intel CPUs

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   test:
     name: Tests and Build
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       -
         name: Checkout
@@ -75,7 +75,7 @@ jobs:
   sign:
     name: Sign Apple app
     needs: [version]
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       -
         name: Checkout
@@ -210,7 +210,7 @@ jobs:
 
   release:
     name: Release
-    runs-on: macos-latest
+    runs-on: macos-13
     needs: [version, sign, changelog]
     steps:
       -


### PR DESCRIPTION
New `macos-latest` GitHub runner defaults to ARM, but we need to support Intel:

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories