### PR TITLE
Always show monitored app even when not running

### DIFF
--- a/WakaTime/Views/MonitoredAppsView.swift
+++ b/WakaTime/Views/MonitoredAppsView.swift
@@ -11,9 +11,9 @@ class MonitoredAppsView: NSView, NSOutlineViewDataSource, NSOutlineViewDelegate 
     private var outlineView: NSOutlineView!
     private var runningApps: [AppData] = []
 
-    private func refreshRunningApps() -> [AppData] {
+    private func refreshRunningApps() {
         var apps = [AppData]()
-        let bundleIds = sort(MonitoredApp.allBundleIds + getRunningApps())
+        let bundleIds = sort(Array(Set(MonitoredApp.allBundleIds + getRunningApps() + MonitoringManager.allMonitoredApps)))
         var index = 0
         for bundleId in bundleIds {
             if let icon = AppInfo.getIcon(bundleId: bundleId),
@@ -30,7 +30,6 @@ class MonitoredAppsView: NSView, NSOutlineViewDataSource, NSOutlineViewDelegate 
             }
         }
         runningApps = apps
-        return apps
     }
 
     private func getRunningApps() -> [String] {

--- a/WakaTime/WakaTime.swift
+++ b/WakaTime/WakaTime.swift
@@ -33,17 +33,6 @@ class WakaTime: HeartbeatEventHandler {
         watcher.heartbeatEventHandler = self
         watcher.statusBarDelegate = delegate
 
-        // In local dev builds, print bundle-ids of all running apps to Xcode console
-        if Dependencies.isLocalDevBuild {
-            Logging.default.log("********* Start Running Applications *********")
-            for runningApp in NSWorkspace.shared.runningApplications where runningApp.activationPolicy == .regular {
-                if let name = runningApp.localizedName, let id = runningApp.bundleIdentifier {
-                    Logging.default.log("\(name): \(id)")
-                }
-            }
-            Logging.default.log("********* End Running Applications *********")
-        }
-
         if !PropertiesManager.hasLaunchedBefore {
             for bundleId in MonitoredApp.defaultEnabledApps {
                 MonitoringManager.enableByDefault(bundleId)


### PR DESCRIPTION
Previously, if an app was monitored but not running then it would be missing from the `Monitored Apps` menu list.