### PR TITLE
Add support for Chrome Beta and Chrome Canary

### DIFF
--- a/WakaTime/Helpers/MonitoringManager.swift
+++ b/WakaTime/Helpers/MonitoringManager.swift
@@ -198,7 +198,7 @@ class MonitoringManager {
                 fatalError("\(monitoredApp.rawValue) should never use window title as entity")
             case .canva:
                 fatalError("\(monitoredApp.rawValue) should never use window title as entity")
-            case .chrome:
+            case .chrome, .chromebeta, .chromecanary:
                 fatalError("\(monitoredApp.rawValue) should never use window title as entity")
             case .figma:
                 guard
@@ -287,7 +287,7 @@ class MonitoringManager {
                 return .browsing
             case .canva:
                 return .designing
-            case .chrome:
+            case .chrome, .chromebeta, .chromecanary:
                 return .browsing
             case .figma:
                 return .designing
@@ -418,7 +418,7 @@ class MonitoringManager {
         switch monitoredApp {
             case .canva:
                 return "Image (svg)"
-            case .chrome:
+            case .chrome, .chromebeta, .chromecanary:
                 do {
                     guard let url = currentBrowserUrl(for: app, element) else { return nil }
 
@@ -464,7 +464,7 @@ class MonitoringManager {
             case .brave:
                 let addressField = element.findAddressField()
                 address = addressField?.value
-            case .chrome:
+            case .chrome, .chromebeta, .chromecanary:
                 let addressField = element.findAddressField()
                 address = addressField?.value
             case .firefox:

--- a/WakaTime/Watchers/MonitoredApp.swift
+++ b/WakaTime/Watchers/MonitoredApp.swift
@@ -12,6 +12,8 @@ enum MonitoredApp: String, CaseIterable {
     case brave = "com.brave.Browser"
     case canva = "com.canva.CanvaDesktop"
     case chrome = "com.google.Chrome"
+    case chromebeta = "com.google.Chrome.beta"
+    case chromecanary = "com.google.Chrome.canary"
     case figma = "com.figma.Desktop"
     case firefox = "org.mozilla.firefox"
     case github = "com.github.GitHubClient"
@@ -101,6 +103,8 @@ enum MonitoredApp: String, CaseIterable {
         MonitoredApp.arcbrowser.rawValue,
         MonitoredApp.brave.rawValue,
         MonitoredApp.chrome.rawValue,
+        MonitoredApp.chromebeta.rawValue,
+        MonitoredApp.chromecanary.rawValue,
         MonitoredApp.firefox.rawValue,
         MonitoredApp.safari.rawValue,
         MonitoredApp.safaripreview.rawValue,


### PR DESCRIPTION
This is a simple addition of the Chrome Beta and Chrome Canary app ID's which will allow those apps to be marked as browsing time and have the same rules applied as regular Google Chrome.