### PR TITLE
Add option to hide minutes in status bar

### DIFF
--- a/WakaTime/AppDelegate.swift
+++ b/WakaTime/AppDelegate.swift
@@ -210,6 +210,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, StatusBarDelegate {
         }
     }
 
+    private func formatTimeText(_ text: String) -> String {
+        if !PropertiesManager.shouldDisplayTodayMinutesInStatusBar {
+            let parts = text.components(separatedBy: " ")
+            return parts[0] + " " + parts[1]
+        } else {
+            return text
+        }
+    }
+
     internal func fetchToday() {
         guard PropertiesManager.shouldDisplayTodayInStatusBar else {
             setText("")
@@ -218,7 +227,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, StatusBarDelegate {
 
         let time = Int(NSDate().timeIntervalSince1970)
         guard lastTodayTime + 120 < time else {
-            setText(lastTodayText)
+            setText(formatTimeText(lastTodayText))
             return
         }
 
@@ -254,6 +263,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, StatusBarDelegate {
         let data = handle.readDataToEndOfFile()
         let text = (String(data: data, encoding: String.Encoding.utf8) ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         lastTodayText = text
-        setText(text)
+        setText(formatTimeText(text))
     }
 }

--- a/WakaTime/Helpers/PropertiesManager.swift
+++ b/WakaTime/Helpers/PropertiesManager.swift
@@ -18,6 +18,7 @@ class PropertiesManager {
         case shouldAutomaticallyDownloadUpdates = "should_automatically_download_updates"
         case hasLaunchedBefore = "has_launched_before"
         case shouldDisplayTodayInStatusBar = "status_bar_text"
+        case shouldDisplayTodayMinutesInStatusBar = "status_bar_minutes"
         case domainPreference = "domain_preference"
         case filterType = "filter_type"
         case denylist = "denylist"
@@ -100,6 +101,21 @@ class PropertiesManager {
         }
         set {
             UserDefaults.standard.set(newValue, forKey: Keys.shouldDisplayTodayInStatusBar.rawValue)
+            UserDefaults.standard.synchronize()
+        }
+    }
+
+    static var shouldDisplayTodayMinutesInStatusBar: Bool {
+        get {
+            guard UserDefaults.standard.string(forKey: Keys.shouldDisplayTodayMinutesInStatusBar.rawValue) != nil else {
+                UserDefaults.standard.set(true, forKey: Keys.shouldDisplayTodayMinutesInStatusBar.rawValue)
+                return true
+            }
+
+            return UserDefaults.standard.bool(forKey: Keys.shouldDisplayTodayMinutesInStatusBar.rawValue)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: Keys.shouldDisplayTodayMinutesInStatusBar.rawValue)
             UserDefaults.standard.synchronize()
         }
     }

--- a/WakaTime/Views/SettingsView.swift
+++ b/WakaTime/Views/SettingsView.swift
@@ -56,6 +56,16 @@ class SettingsView: NSView, NSTextFieldDelegate, NSTextViewDelegate {
         return checkbox
     }()
 
+    lazy var statusBarMinutesCheckbox: NSButton = {
+        let checkbox = NSButton(
+            checkboxWithTitle: "Show minutes in status bar",
+            target: self,
+            action: #selector(enableStatusBarMinutesCheckboxClicked)
+        )
+        checkbox.state = PropertiesManager.shouldDisplayTodayMinutesInStatusBar ? .on : .off
+        return checkbox
+    }()
+
     lazy var requestA11yCheckbox: NSButton = {
         let checkbox = NSButton(
             checkboxWithTitle: "Enable stats from Xcode by requesting accessibility permission",
@@ -67,7 +77,13 @@ class SettingsView: NSView, NSTextFieldDelegate, NSTextViewDelegate {
     }()
 
     lazy var checkboxesStackView: NSStackView = {
-        let stack = NSStackView(views: [launchAtLoginCheckbox, statusBarTextCheckbox, requestA11yCheckbox, enableLoggingCheckbox])
+        let stack = NSStackView(views: [
+            launchAtLoginCheckbox,
+            statusBarTextCheckbox,
+            statusBarMinutesCheckbox,
+            requestA11yCheckbox,
+            enableLoggingCheckbox
+        ])
         stack.alignment = .leading
         stack.orientation = .vertical
         stack.spacing = 10
@@ -261,6 +277,16 @@ class SettingsView: NSView, NSTextFieldDelegate, NSTextViewDelegate {
             PropertiesManager.shouldDisplayTodayInStatusBar = true
         } else {
             PropertiesManager.shouldDisplayTodayInStatusBar = false
+        }
+        delegate?.fetchToday()
+    }
+
+    @objc func enableStatusBarMinutesCheckboxClicked() {
+        PropertiesManager.shouldDisplayTodayMinutesInStatusBar = statusBarMinutesCheckbox.state == .on
+        if statusBarMinutesCheckbox.state == .on {
+            PropertiesManager.shouldDisplayTodayMinutesInStatusBar = true
+        } else {
+            PropertiesManager.shouldDisplayTodayMinutesInStatusBar = false
         }
         delegate?.fetchToday()
     }


### PR DESCRIPTION
This change can shorten the time display in the status bar.
It can be changed in the settings whether the minutes are displayed or not.

<img width="118" alt="image" src="https://github.com/user-attachments/assets/900054a5-a01e-46ae-a2a8-741707b7b850" />
<img width="68" alt="image" src="https://github.com/user-attachments/assets/4a59784f-78b1-40f7-b002-5f96a0e47fa0" />
