### PR TITLE
Exclude tracking apps that now have plugins

### DIFF
--- a/WakaTime/Helpers/MonitoringManager.swift
+++ b/WakaTime/Helpers/MonitoringManager.swift
@@ -82,7 +82,7 @@ class MonitoringManager {
 
     static var allMonitoredApps: [String] {
         if let bundleIds = UserDefaults.standard.stringArray(forKey: monitoringKey) {
-            return bundleIds
+            return bundleIds.filter { MonitoredApp.pluginAppIds[$0] == nil }
         } else {
             var bundleIds: [String] = []
             let defaults = UserDefaults.standard.dictionaryRepresentation()
@@ -97,7 +97,7 @@ class MonitoringManager {
             }
             UserDefaults.standard.set(bundleIds, forKey: monitoringKey)
             UserDefaults.standard.synchronize()
-            return bundleIds
+            return bundleIds.filter { MonitoredApp.pluginAppIds[$0] == nil }
         }
     }
 


### PR DESCRIPTION
When a new plugin is added to [MonitoredApp.pluginAppIds](https://github.com/wakatime/macos-wakatime/blob/1d8fd1c7cb8214c6f32343b551ed7a3ae872b304/WakaTime/Watchers/MonitoredApp.swift#L57) that was previously enabled for tracking, there's no way to disable tracking for that app now that the toggle switch becomes a link to the plugin install page.

This PR fixes that by not tracking apps listed as having plugins.