### PR TITLE
Use the Wakatime config for Dashboard URL

### DIFF
--- a/WakaTime/AppDelegate.swift
+++ b/WakaTime/AppDelegate.swift
@@ -107,7 +107,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, StatusBarDelegate, UNUserNot
     }
 
     @objc func dashboardClicked(_ sender: AnyObject) {
-        if let url = URL(string: "https://wakatime.com/") {
+        guard let urlString = ConfigFile.getSetting(section: "settings", key: "api_url") else {
+            Logging.default.log("No `api_url` was set in the config!")
+            return
+        }
+
+        if let url = URL(string: urlString) {
+            // When you go to the `api_url`, it redirects to the dashboard.
             NSWorkspace.shared.open(url)
         }
     }


### PR DESCRIPTION
Previously, the "Dashboard" button will always send users to https://wakatime.com, regardless of the `api_url` that they use.  This can cause problems, especially when and if you're using a 3rd party Wakatime server, such as [Hakatime](https://hackatime.hackclub.org).

One caveat is that this requires the `api_url` to be set in the user's Wakatime config, but realistically, that shouldn't be a problem, as you'd either not change your config manually (automatically generate it), or if you do change it, you'd realistically make sure that `api_url` is set, so I doubt that this would be an issue.