### PR TITLE
Fix typo in Branching Strategy section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Build with `Xcode` before creating any pull requests, or your PR won’t pass th
 
 To fix linter warning(s), run `swiftlint --fix`.
 
-## Branching Stratgegy
+## Branching Strategy
 
 We require specific branch name prefixes for PRs:
 


### PR DESCRIPTION
Change the typo from "Stratgegy" to "Strategy"