### PR TITLE
Fix parsing category from browser url

### DIFF
--- a/WakaTime/Helpers/MonitoringManager.swift
+++ b/WakaTime/Helpers/MonitoringManager.swift
@@ -283,12 +283,20 @@ class MonitoringManager {
                 return .designing
             case .adobepremierepro:
                 return .designing
+            case .arcbrowser:
+                return .browsing
             case .beeper:
                 return .communicating
+            case .brave:
+                return .browsing
             case .canva:
                 return .designing
+            case .chrome, .chromebeta, .chromecanary:
+                return .browsing
             case .figma:
                 return .designing
+            case .firefox:
+                return .browsing
             case .github:
                 return .codereviewing
             case .imessage:
@@ -311,6 +319,10 @@ class MonitoringManager {
                 return .communicating
             case .slack:
                 return .communicating
+            case .safari:
+                return .browsing
+            case .safaripreview:
+                return .browsing
             case .tableplus:
                 return .debugging
             case .terminal:
@@ -326,8 +338,6 @@ class MonitoringManager {
             case .zoom:
                 return .meeting
             case .zed:
-                return .coding
-            default:
                 return .coding
         }
     }
@@ -353,7 +363,7 @@ class MonitoringManager {
             }
         }
 
-        return .browsing
+        return .coding
     }
 
     static func project(for app: NSRunningApplication, _ element: AXUIElement) -> String? {


### PR DESCRIPTION
PR #317 introduced a function to determine the heartbeat category from the browser URL. The function call was made impossible to reach, though. This, as it was part of the guard statement and, hence, would execute only for unmonitored apps, which in turn do not result in a valid browser URL. This PR aims to make the function call reachable for browser apps for which we can find a URL.