### PR TITLE
Improve performance on Apple Notes

### DIFF
--- a/WakaTime/Extensions/AXUIElementExtension.swift
+++ b/WakaTime/Extensions/AXUIElementExtension.swift
@@ -133,11 +133,15 @@ extension AXUIElement {
         }
     }
 
-    func traverseDownDFS(visitor: (AXUIElement) -> Bool) {
+    func traverseDownDFS(
+        visitor: (AXUIElement) -> Bool,
+        skipDescendantsWhere: ((AXUIElement) -> Bool)? = nil
+    ) {
         var stack: [AXUIElement] = [self]
         while !stack.isEmpty {
             let currentElement = stack.removeLast()
             if !visitor(currentElement) { return }
+            if skipDescendantsWhere?(currentElement) == true { continue }
             if let children = currentElement.children {
                 stack.append(contentsOf: children.reversed())
             }
@@ -153,15 +157,18 @@ extension AXUIElement {
         }
     }
 
-    func firstDescendantWhere(_ condition: (AXUIElement) -> Bool) -> AXUIElement? {
+    func firstDescendantWhere(
+        _ condition: (AXUIElement) -> Bool,
+        skipDescendantsWhere: ((AXUIElement) -> Bool)? = nil
+    ) -> AXUIElement? {
         var matchingDescendant: AXUIElement?
-        traverseDownDFS { element in
+        traverseDownDFS(visitor: { element in
             if condition(element) {
                 matchingDescendant = element
                 return false // stop traversal
             }
             return true // continue traversal
-        }
+        }, skipDescendantsWhere: skipDescendantsWhere)
         return matchingDescendant
     }
 

--- a/WakaTime/Helpers/MonitoringManager.swift
+++ b/WakaTime/Helpers/MonitoringManager.swift
@@ -150,16 +150,34 @@ class MonitoringManager {
                 let webArea = someElem?.firstAncestorWhere { $0.role == "AXWebArea" }
                 return (webArea?.rawTitle, .app)
             case .notes:
+                let skipHighCostElements: (AXUIElement) -> Bool = { element in
+                    guard let role = element.role else { return false }
+
+                    // If we don't skip them, Notes app itself costs a lot of CPU time to create AXUIElement for us to traverse.
+                    // AXOutline -> Folder Sidebar of Notes
+                    // AXTable   -> List View of items of selected folder. It may contain thousands of rows, and each row may have text and image element.
+                    if role == "AXOutline" || role == "AXTable" {
+                        return true
+                    }
+
+                    return false
+                }
                 // There's apparently two text editor implementations in Apple Notes. One uses a web view,
                 // the other appears to be a native implementation based on the `ICTK2MacTextView` class.
-                let webAreaElement = element.firstDescendantWhere { $0.role == "AXWebArea" }
+                let webAreaElement = element.firstDescendantWhere(
+                    { $0.role == "AXWebArea" },
+                    skipDescendantsWhere: skipHighCostElements
+                )
                 if let webAreaElement {
                     // WebView-based implementation
                     let titleElement = webAreaElement.firstDescendantWhere { $0.role == kAXStaticTextRole }
                     return (titleElement?.value, .app)
                 } else {
                     // ICTK2MacTextView
-                    let textAreaElement = element.firstDescendantWhere { $0.role == kAXTextAreaRole }
+                    let textAreaElement = element.firstDescendantWhere(
+                        { $0.role == kAXTextAreaRole },
+                        skipDescendantsWhere: skipHighCostElements
+                    )
                     if let value = textAreaElement?.value {
                         let title = extractPrefix(value, separator: "\n")
                         return (title, .app)


### PR DESCRIPTION
Thanks for making such a tool for us dev to trace the time distribution of Apps! Recently I experienced worse performance on Apple Notes when I edit my notes as the number of notes grows.

From Activity Monitor, I found Notes use nearly 100% of cpu after i edit a file and the high cpu could last at least 1 minute. I made profile on Notes process and the profile shows that Notes was creating UI Elements for accessibility views.

<img width="1174" height="733" alt="image" src="https://github.com/user-attachments/assets/8e21a946-0965-4b12-a800-8b861b85f0c0" />

<img width="1498" height="860" alt="image" src="https://github.com/user-attachments/assets/7b238220-fdee-4b16-84b6-bb88b4efad0f" />

I tried to close apps that requires accessibility one by one and found it was WakaTime.app makes Notes.app consume high CPU usage, so I realized that there must be some logics in WakaTime.app that traverses accessibility UI Elements deeply to get some data for its usage purpose.

After digging the implementations. When for `.notes`, WakaTime.app DFS the whole a11y tree just to check the type of view and to get the title of what i am editing.

If I have nearly 1000 notes, the whole DFS process consumes lots of CPU time since it creates lots of views.

> PS: the official a11y inspector from XCode is also stuck 😂

<img width="639" height="765" alt="image" src="https://github.com/user-attachments/assets/33b61978-eb7d-4bfb-b25d-03e7a957e787" />

So I add a skip condition for DFS to skip the children of unnecessary node to boost the whole logic. After the fix it quickly finishes its work.

<img width="762" height="212" alt="image" src="https://github.com/user-attachments/assets/a92be57d-2330-44fc-ada8-d31ead285dde" />
