### PR TITLE
Added toggle to hide the big chunk of text when you haven't coded anything yet today

### DIFF
--- a/WakaTime/AppDelegate.swift
+++ b/WakaTime/AppDelegate.swift
@@ -265,7 +265,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, StatusBarDelegate, UNUserNot
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard !trimmed.isEmpty else { return "" }
-        guard !trimmed.hasPrefix("Start") else { return "" }
+        
+        if !PropertiesManager.shouldShowEmptyText {
+            guard !trimmed.hasPrefix("Start") else { return "" }
+        }
 
         return trimmed
     }

--- a/WakaTime/AppDelegate.swift
+++ b/WakaTime/AppDelegate.swift
@@ -261,6 +261,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, StatusBarDelegate, UNUserNot
         }
     }
 
+    private func normalizedTodayText(_ text: String) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmed.isEmpty else { return "" }
+        guard !trimmed.hasPrefix("Start") else { return "" }
+
+        return trimmed
+    }
+
     internal func fetchToday() {
         guard PropertiesManager.shouldDisplayTodayInStatusBar else {
             setText("")
@@ -304,7 +313,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, StatusBarDelegate, UNUserNot
 
         let handle = pipe.fileHandleForReading
         let data = handle.readDataToEndOfFile()
-        let text = (String(data: data, encoding: String.Encoding.utf8) ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let text = normalizedTodayText(String(data: data, encoding: String.Encoding.utf8) ?? "")
         lastTodayText = text
         setText(text)
 

--- a/WakaTime/AppDelegate.swift
+++ b/WakaTime/AppDelegate.swift
@@ -273,6 +273,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, StatusBarDelegate, UNUserNot
         return trimmed
     }
 
+    internal func refreshToday() {
+        lastTodayTime = 0
+        fetchToday()
+    }
+
     internal func fetchToday() {
         guard PropertiesManager.shouldDisplayTodayInStatusBar else {
             setText("")

--- a/WakaTime/Helpers/PropertiesManager.swift
+++ b/WakaTime/Helpers/PropertiesManager.swift
@@ -18,6 +18,7 @@ class PropertiesManager {
         case shouldAutomaticallyDownloadUpdates = "should_automatically_download_updates"
         case hasLaunchedBefore = "has_launched_before"
         case shouldDisplayTodayInStatusBar = "status_bar_text"
+        case shouldShowEmptyText = "show_empty_text"
         case domainPreference = "domain_preference"
         case filterType = "filter_type"
         case denylist = "denylist"
@@ -100,6 +101,21 @@ class PropertiesManager {
         }
         set {
             UserDefaults.standard.set(newValue, forKey: Keys.shouldDisplayTodayInStatusBar.rawValue)
+            UserDefaults.standard.synchronize()
+        }
+    }
+
+    static var shouldShowEmptyText: Bool {
+        get {
+            guard UserDefaults.standard.string(forKey: Keys.shouldShowEmptyText.rawValue) != nil else {
+                UserDefaults.standard.set(false, forKey: Keys.shouldShowEmptyText.rawValue)
+                return false
+            }
+
+            return UserDefaults.standard.bool(forKey: Keys.shouldShowEmptyText.rawValue)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: Keys.shouldShowEmptyText.rawValue)
             UserDefaults.standard.synchronize()
         }
     }

--- a/WakaTime/Views/SettingsView.swift
+++ b/WakaTime/Views/SettingsView.swift
@@ -56,6 +56,16 @@ class SettingsView: NSView, NSTextFieldDelegate, NSTextViewDelegate {
         return checkbox
     }()
 
+    lazy var showEmptyTextCheckbox: NSButton = {
+        let checkbox = NSButton(
+            checkboxWithTitle: "Show empty text when there's no activity",
+            target: self,
+            action: #selector(enableShowEmptyTextCheckboxClicked)
+        )
+        checkbox.state = PropertiesManager.shouldShowEmptyText ? .on : .off
+        return checkbox
+    }()
+
     lazy var requestA11yCheckbox: NSButton = {
         let checkbox = NSButton(
             checkboxWithTitle: "Enable stats from Xcode by requesting accessibility permission",
@@ -67,7 +77,13 @@ class SettingsView: NSView, NSTextFieldDelegate, NSTextViewDelegate {
     }()
 
     lazy var checkboxesStackView: NSStackView = {
-        let stack = NSStackView(views: [launchAtLoginCheckbox, statusBarTextCheckbox, requestA11yCheckbox, enableLoggingCheckbox])
+        let stack = NSStackView(views: [
+            launchAtLoginCheckbox,
+            statusBarTextCheckbox,
+            showEmptyTextCheckbox,
+            requestA11yCheckbox,
+            enableLoggingCheckbox
+        ])
         stack.alignment = .leading
         stack.orientation = .vertical
         stack.spacing = 10
@@ -262,6 +278,11 @@ class SettingsView: NSView, NSTextFieldDelegate, NSTextViewDelegate {
         } else {
             PropertiesManager.shouldDisplayTodayInStatusBar = false
         }
+        delegate?.fetchToday()
+    }
+
+    @objc func enableShowEmptyTextCheckboxClicked() {
+        PropertiesManager.shouldShowEmptyText = showEmptyTextCheckbox.state == .on
         delegate?.fetchToday()
     }
 

--- a/WakaTime/Views/SettingsView.swift
+++ b/WakaTime/Views/SettingsView.swift
@@ -56,13 +56,13 @@ class SettingsView: NSView, NSTextFieldDelegate, NSTextViewDelegate {
         return checkbox
     }()
 
-    lazy var showEmptyTextCheckbox: NSButton = {
+    lazy var hideEmptyTextCheckbox: NSButton = {
         let checkbox = NSButton(
-            checkboxWithTitle: "Show empty text when there's no activity",
+            checkboxWithTitle: "Hide empty text when there's no activity",
             target: self,
-            action: #selector(enableShowEmptyTextCheckboxClicked)
+            action: #selector(enableHideEmptyTextCheckboxClicked)
         )
-        checkbox.state = PropertiesManager.shouldShowEmptyText ? .on : .off
+        checkbox.state = PropertiesManager.shouldShowEmptyText ? .off : .on
         return checkbox
     }()
 
@@ -80,7 +80,7 @@ class SettingsView: NSView, NSTextFieldDelegate, NSTextViewDelegate {
         let stack = NSStackView(views: [
             launchAtLoginCheckbox,
             statusBarTextCheckbox,
-            showEmptyTextCheckbox,
+            hideEmptyTextCheckbox,
             requestA11yCheckbox,
             enableLoggingCheckbox
         ])
@@ -278,12 +278,12 @@ class SettingsView: NSView, NSTextFieldDelegate, NSTextViewDelegate {
         } else {
             PropertiesManager.shouldDisplayTodayInStatusBar = false
         }
-        delegate?.fetchToday()
+        delegate?.refreshToday()
     }
 
-    @objc func enableShowEmptyTextCheckboxClicked() {
-        PropertiesManager.shouldShowEmptyText = showEmptyTextCheckbox.state == .on
-        delegate?.fetchToday()
+    @objc func enableHideEmptyTextCheckboxClicked() {
+        PropertiesManager.shouldShowEmptyText = hideEmptyTextCheckbox.state == .off
+        delegate?.refreshToday()
     }
 
     @objc func enableA11yCheckboxClicked() {

--- a/WakaTime/WakaTime.swift
+++ b/WakaTime/WakaTime.swift
@@ -191,6 +191,7 @@ enum Category: String {
 protocol StatusBarDelegate: AnyObject {
     func a11yStatusChanged(_ hasPermission: Bool)
     func toastNotification(_ title: String)
+    func refreshToday()
     func fetchToday()
 }
 


### PR DESCRIPTION
The implementation is not great at all, but basically: I thought that the menubar text taking half my menubar's space wasn't that great, so I added a toggle to hide the text only when it's the empty placeholder the API returns
<img width="566" height="70" alt="CleanShot 2026-05-22 at 09 20 42@2x" src="https://github.com/user-attachments/assets/37956886-8331-4047-9679-ab0af899ffe6" />
