### PR TITLE
Fix Zed title parsing

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -22,6 +22,9 @@ jobs:
         name: Generate project
         run: xcodegen
       -
+        name: Run tests
+        run: xcodebuild -scheme WakaTime -configuration Debug -destination 'platform=macOS' test
+      -
         name: Build app to run linters
         run: xcodebuild -scheme WakaTime -configuration Debug -destination 'generic/platform=macOS' ONLY_ACTIVE_ARCH=NO ARCHS='arm64 x86_64' build
 

--- a/WakaTime/Helpers/MonitoringManager.swift
+++ b/WakaTime/Helpers/MonitoringManager.swift
@@ -48,28 +48,36 @@ class MonitoringManager {
 
         guard let activeWindow = AXUIElementCreateApplication(pid).activeWindow else { return nil }
 
-        let heartbeatEntity: (String?, EntityType)?
-        let heartbeatProject: String?
+        let entity: String
+        let entityType: EntityType
+        let project: String?
         if app.monitoredApp == .zed {
             let title = zedTitle(for: app, activeWindow)
-            heartbeatEntity = (title.entity, .app)
-            heartbeatProject = title.project
+            guard let titleEntity = title.entity else { return nil }
+
+            entity = titleEntity
+            entityType = .app
+            project = title.project
         } else {
-            heartbeatEntity = entity(for: app, activeWindow)
-            heartbeatProject = project(for: app, activeWindow)
+            guard
+                let heartbeatEntity = Self.entity(for: app, activeWindow),
+                let entityValue = heartbeatEntity.0
+            else { return nil }
+
+            entity = entityValue
+            entityType = heartbeatEntity.1
+            project = Self.project(for: app, activeWindow)
         }
 
-        guard let heartbeatEntity, let entity = heartbeatEntity.0 else { return nil }
-
         var language = language(for: app, activeWindow)
-        if heartbeatProject != nil && language == nil {
+        if project != nil && language == nil {
             language = "<<LAST_LANGUAGE>>"
         }
 
         let heartbeat = HeartbeatData(
             entity: entity,
-            entityType: heartbeatEntity.1,
-            project: heartbeatProject,
+            entityType: entityType,
+            project: project,
             language: language,
             category: category(for: app, activeWindow)
         )

--- a/WakaTime/Helpers/MonitoringManager.swift
+++ b/WakaTime/Helpers/MonitoringManager.swift
@@ -46,22 +46,30 @@ class MonitoringManager {
     static func heartbeatData(_ app: NSRunningApplication) -> HeartbeatData? {
         let pid = app.processIdentifier
 
-        guard
-            let activeWindow = AXUIElementCreateApplication(pid).activeWindow,
-            let entity = entity(for: app, activeWindow),
-            let entityUnwrapped = entity.0
-        else { return nil }
+        guard let activeWindow = AXUIElementCreateApplication(pid).activeWindow else { return nil }
 
-        let project = project(for: app, activeWindow)
+        let heartbeatEntity: (String?, EntityType)?
+        let heartbeatProject: String?
+        if app.monitoredApp == .zed {
+            let title = zedTitle(for: app, activeWindow)
+            heartbeatEntity = (title.entity, .app)
+            heartbeatProject = title.project
+        } else {
+            heartbeatEntity = entity(for: app, activeWindow)
+            heartbeatProject = project(for: app, activeWindow)
+        }
+
+        guard let heartbeatEntity, let entity = heartbeatEntity.0 else { return nil }
+
         var language = language(for: app, activeWindow)
-        if project != nil && language == nil {
+        if heartbeatProject != nil && language == nil {
             language = "<<LAST_LANGUAGE>>"
         }
 
         let heartbeat = HeartbeatData(
-            entity: entityUnwrapped,
-            entityType: entity.1,
-            project: project,
+            entity: entity,
+            entityType: heartbeatEntity.1,
+            project: heartbeatProject,
             language: language,
             category: category(for: app, activeWindow)
         )
@@ -273,7 +281,7 @@ class MonitoringManager {
             case .zoom:
                 return extractPrefix(element.rawTitle, separator: " - ")
             case .zed:
-                return extractPrefix(element.rawTitle, separator: " — ")
+                return zedTitle(for: app, element).entity
         }
     }
 
@@ -392,11 +400,16 @@ class MonitoringManager {
             case .slack:
                 return extractSuffix(element.rawTitle, separator: " - ", offset: 1)
             case .zed:
-                return extractSuffix(element.rawTitle, separator: " — ")
+                return zedTitle(for: app, element).project
             default:
                 guard let url = currentBrowserUrl(for: app, element) else { return nil }
                 return project(from: url)
         }
+    }
+
+    private static func zedTitle(for app: NSRunningApplication, _ element: AXUIElement) -> ZedTitleParser.Result {
+        let version = app.bundleURL.flatMap { Bundle(url: $0)?.version }
+        return ZedTitleParser.parse(element.rawTitle, version: version)
     }
 
     struct Pattern {

--- a/WakaTime/Helpers/ZedTitleParser.swift
+++ b/WakaTime/Helpers/ZedTitleParser.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+struct ZedTitleParser {
+    struct Result {
+        let entity: String?
+        let project: String?
+    }
+
+    private static let currentTitleOrderVersion = [0, 162, 0]
+    private static let separator = " — "
+
+    static func parse(_ title: String?, version: String?) -> Result {
+        guard let title, !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return Result(entity: nil, project: nil)
+        }
+
+        let projectFirst = usesCurrentTitleOrder(version)
+        let options: String.CompareOptions = projectFirst ? [] : .backwards
+        guard let separatorRange = title.range(of: separator, options: options) else {
+            return Result(entity: nonEmpty(title), project: nil)
+        }
+
+        let prefix = nonEmpty(String(title[..<separatorRange.lowerBound]))
+        let suffix = nonEmpty(String(title[separatorRange.upperBound...]))
+        let entity = projectFirst ? suffix : prefix
+        let project = projectFirst ? prefix : suffix
+
+        guard let entity else { return Result(entity: nil, project: nil) }
+        return Result(entity: entity, project: entity == project ? nil : project)
+    }
+
+    private static func usesCurrentTitleOrder(_ version: String?) -> Bool {
+        guard let components = versionComponents(version) else { return true }
+
+        for (component, minimum) in zip(components, currentTitleOrderVersion) where component != minimum {
+            return component > minimum
+        }
+
+        return true
+    }
+
+    private static func versionComponents(_ version: String?) -> [Int]? {
+        guard let version = version?.trimmingCharacters(in: .whitespacesAndNewlines), !version.isEmpty else {
+            return nil
+        }
+
+        let components = version.split(separator: ".", omittingEmptySubsequences: false)
+        guard components.count == 3 else { return nil }
+
+        let numbers = components.compactMap { component -> Int? in
+            guard !component.isEmpty, component.allSatisfy(\.isASCII), component.allSatisfy(\.isNumber) else {
+                return nil
+            }
+            return Int(component)
+        }
+
+        return numbers.count == 3 ? numbers : nil
+    }
+
+    private static func nonEmpty(_ component: String) -> String? {
+        let component = component.trimmingCharacters(in: .whitespacesAndNewlines)
+        return component.isEmpty ? nil : component
+    }
+}

--- a/WakaTime/Helpers/ZedTitleParser.swift
+++ b/WakaTime/Helpers/ZedTitleParser.swift
@@ -6,15 +6,13 @@ struct ZedTitleParser {
         let project: String?
     }
 
-    private static let currentTitleOrderVersion = [0, 162, 0]
+    private static let projectFirstVersion = [0, 162, 0]
     private static let separator = " — "
 
     static func parse(_ title: String?, version: String?) -> Result {
-        guard let title, !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            return Result(entity: nil, project: nil)
-        }
+        guard let title else { return Result(entity: nil, project: nil) }
 
-        let projectFirst = usesCurrentTitleOrder(version)
+        let projectFirst = usesProjectFirstTitleOrder(version)
         let options: String.CompareOptions = projectFirst ? [] : .backwards
         guard let separatorRange = title.range(of: separator, options: options) else {
             return Result(entity: nonEmpty(title), project: nil)
@@ -29,10 +27,10 @@ struct ZedTitleParser {
         return Result(entity: entity, project: entity == project ? nil : project)
     }
 
-    private static func usesCurrentTitleOrder(_ version: String?) -> Bool {
+    private static func usesProjectFirstTitleOrder(_ version: String?) -> Bool {
         guard let components = versionComponents(version) else { return true }
 
-        for (component, minimum) in zip(components, currentTitleOrderVersion) where component != minimum {
+        for (component, minimum) in zip(components, projectFirstVersion) where component != minimum {
             return component > minimum
         }
 

--- a/WakaTimeTests/ZedTitleParserTests.swift
+++ b/WakaTimeTests/ZedTitleParserTests.swift
@@ -3,59 +3,45 @@ import XCTest
 
 final class ZedTitleParserTests: XCTestCase {
     func testUsesLegacyTitleOrderBeforeVersionZeroPointOneSixtyTwo() {
-        let result = ZedTitleParser.parse("Cargo.toml — gendervibes", version: "0.161.2")
+        let result = ZedTitleParser.parse("main.swift — sample-project", version: "0.161.2")
 
-        XCTAssertEqual(result.entity, "Cargo.toml")
-        XCTAssertEqual(result.project, "gendervibes")
+        XCTAssertEqual(result.entity, "main.swift")
+        XCTAssertEqual(result.project, "sample-project")
     }
 
     func testUsesCurrentTitleOrderFromVersionZeroPointOneSixtyTwo() {
-        let result = ZedTitleParser.parse("gendervibes — Cargo.toml", version: "0.162.0")
+        let result = ZedTitleParser.parse("sample-project — main.swift", version: "0.162.0")
 
-        XCTAssertEqual(result.entity, "Cargo.toml")
-        XCTAssertEqual(result.project, "gendervibes")
+        XCTAssertEqual(result.entity, "main.swift")
+        XCTAssertEqual(result.project, "sample-project")
     }
 
-    func testDefaultsToCurrentTitleOrderWhenVersionIsUnavailable() {
-        let result = ZedTitleParser.parse("gendervibes — Cargo.toml", version: nil)
+    func testDefaultsToCurrentTitleOrderWhenVersionIsUnavailableOrInvalid() {
+        for version in [nil, "unknown", "0.161.2junk", "0.161.2.3"] as [String?] {
+            let result = ZedTitleParser.parse("sample-project — main.swift", version: version)
 
-        XCTAssertEqual(result.entity, "Cargo.toml")
-        XCTAssertEqual(result.project, "gendervibes")
-    }
-
-    func testDefaultsToCurrentTitleOrderWhenVersionIsInvalid() {
-        let result = ZedTitleParser.parse("gendervibes — Cargo.toml", version: "unknown")
-
-        XCTAssertEqual(result.entity, "Cargo.toml")
-        XCTAssertEqual(result.project, "gendervibes")
-    }
-
-    func testDefaultsToCurrentTitleOrderForMalformedNumericVersion() {
-        for version in ["0.161.2junk", "0.161.2.3", "v0.161.2"] {
-            let result = ZedTitleParser.parse("gendervibes — Cargo.toml", version: version)
-
-            XCTAssertEqual(result.entity, "Cargo.toml")
-            XCTAssertEqual(result.project, "gendervibes")
+            XCTAssertEqual(result.entity, "main.swift")
+            XCTAssertEqual(result.project, "sample-project")
         }
     }
 
     func testDoesNotUseEntityAsProjectForAmbiguousTitle() {
-        let result = ZedTitleParser.parse("Cargo.toml — Cargo.toml", version: "1.10.3")
+        let result = ZedTitleParser.parse("main.swift — main.swift", version: "1.10.3")
 
-        XCTAssertEqual(result.entity, "Cargo.toml")
+        XCTAssertEqual(result.entity, "main.swift")
         XCTAssertNil(result.project)
     }
 
     func testKeepsSingleComponentTitleAsEntityWithoutProject() {
-        let result = ZedTitleParser.parse("Cargo.toml", version: "1.10.3")
+        let result = ZedTitleParser.parse("main.swift", version: "1.10.3")
 
-        XCTAssertEqual(result.entity, "Cargo.toml")
+        XCTAssertEqual(result.entity, "main.swift")
         XCTAssertNil(result.project)
     }
 
     func testDoesNotReturnAProjectWithoutAnEntity() {
-        let current = ZedTitleParser.parse("gendervibes — ", version: "1.10.3")
-        let legacy = ZedTitleParser.parse(" — gendervibes", version: "0.161.2")
+        let current = ZedTitleParser.parse("sample-project — ", version: "1.10.3")
+        let legacy = ZedTitleParser.parse(" — sample-project", version: "0.161.2")
 
         XCTAssertNil(current.entity)
         XCTAssertNil(current.project)
@@ -64,12 +50,12 @@ final class ZedTitleParserTests: XCTestCase {
     }
 
     func testPreservesSeparatorsInsideEntity() {
-        let current = ZedTitleParser.parse("gendervibes — foo — bar.swift", version: "1.10.3")
-        let legacy = ZedTitleParser.parse("foo — bar.swift — gendervibes", version: "0.161.2")
+        let current = ZedTitleParser.parse("sample-project — foo — bar.swift", version: "1.10.3")
+        let legacy = ZedTitleParser.parse("foo — bar.swift — sample-project", version: "0.161.2")
 
         XCTAssertEqual(current.entity, "foo — bar.swift")
-        XCTAssertEqual(current.project, "gendervibes")
+        XCTAssertEqual(current.project, "sample-project")
         XCTAssertEqual(legacy.entity, "foo — bar.swift")
-        XCTAssertEqual(legacy.project, "gendervibes")
+        XCTAssertEqual(legacy.project, "sample-project")
     }
 }

--- a/WakaTimeTests/ZedTitleParserTests.swift
+++ b/WakaTimeTests/ZedTitleParserTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import WakaTime
+
+final class ZedTitleParserTests: XCTestCase {
+    func testUsesLegacyTitleOrderBeforeVersionZeroPointOneSixtyTwo() {
+        let result = ZedTitleParser.parse("Cargo.toml — gendervibes", version: "0.161.2")
+
+        XCTAssertEqual(result.entity, "Cargo.toml")
+        XCTAssertEqual(result.project, "gendervibes")
+    }
+
+    func testUsesCurrentTitleOrderFromVersionZeroPointOneSixtyTwo() {
+        let result = ZedTitleParser.parse("gendervibes — Cargo.toml", version: "0.162.0")
+
+        XCTAssertEqual(result.entity, "Cargo.toml")
+        XCTAssertEqual(result.project, "gendervibes")
+    }
+
+    func testDefaultsToCurrentTitleOrderWhenVersionIsUnavailable() {
+        let result = ZedTitleParser.parse("gendervibes — Cargo.toml", version: nil)
+
+        XCTAssertEqual(result.entity, "Cargo.toml")
+        XCTAssertEqual(result.project, "gendervibes")
+    }
+
+    func testDefaultsToCurrentTitleOrderWhenVersionIsInvalid() {
+        let result = ZedTitleParser.parse("gendervibes — Cargo.toml", version: "unknown")
+
+        XCTAssertEqual(result.entity, "Cargo.toml")
+        XCTAssertEqual(result.project, "gendervibes")
+    }
+
+    func testDefaultsToCurrentTitleOrderForMalformedNumericVersion() {
+        for version in ["0.161.2junk", "0.161.2.3", "v0.161.2"] {
+            let result = ZedTitleParser.parse("gendervibes — Cargo.toml", version: version)
+
+            XCTAssertEqual(result.entity, "Cargo.toml")
+            XCTAssertEqual(result.project, "gendervibes")
+        }
+    }
+
+    func testDoesNotUseEntityAsProjectForAmbiguousTitle() {
+        let result = ZedTitleParser.parse("Cargo.toml — Cargo.toml", version: "1.10.3")
+
+        XCTAssertEqual(result.entity, "Cargo.toml")
+        XCTAssertNil(result.project)
+    }
+
+    func testKeepsSingleComponentTitleAsEntityWithoutProject() {
+        let result = ZedTitleParser.parse("Cargo.toml", version: "1.10.3")
+
+        XCTAssertEqual(result.entity, "Cargo.toml")
+        XCTAssertNil(result.project)
+    }
+
+    func testDoesNotReturnAProjectWithoutAnEntity() {
+        let current = ZedTitleParser.parse("gendervibes — ", version: "1.10.3")
+        let legacy = ZedTitleParser.parse(" — gendervibes", version: "0.161.2")
+
+        XCTAssertNil(current.entity)
+        XCTAssertNil(current.project)
+        XCTAssertNil(legacy.entity)
+        XCTAssertNil(legacy.project)
+    }
+
+    func testPreservesSeparatorsInsideEntity() {
+        let current = ZedTitleParser.parse("gendervibes — foo — bar.swift", version: "1.10.3")
+        let legacy = ZedTitleParser.parse("foo — bar.swift — gendervibes", version: "0.161.2")
+
+        XCTAssertEqual(current.entity, "foo — bar.swift")
+        XCTAssertEqual(current.project, "gendervibes")
+        XCTAssertEqual(legacy.entity, "foo — bar.swift")
+        XCTAssertEqual(legacy.project, "gendervibes")
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -66,3 +66,10 @@ targets:
     postCompileScripts:
       - script: ./Scripts/Lint/swiftlint lint --quiet
         name: Swiftlint
+  WakaTimeTests:
+    type: bundle.unit-test
+    platform: macOS
+    deploymentTarget: 10.15
+    sources: [WakaTimeTests]
+    dependencies:
+      - target: WakaTime


### PR DESCRIPTION
## Summary

Fix Zed title parsing for the order introduced in Zed 0.162.0.

Use the installed Zed version when available. Fall back to the current order when it cannot be read.

## Tests

- Added Zed title parser tests
- Passed 7 macOS tests and the universal app build